### PR TITLE
YM-277 | Refactor GQL API to have a separate YouthProfileNode type

### DIFF
--- a/youths/schema/mutations.py
+++ b/youths/schema/mutations.py
@@ -327,10 +327,23 @@ class ApproveYouthProfileMutation(relay.ClientIDMutation):
         youth_data = input.get("approval_data")
         token = input.get("approval_token")
 
+        contact_persons_to_create = youth_data.pop("add_additional_contact_persons", [])
+        contact_persons_to_update = youth_data.pop(
+            "update_additional_contact_persons", []
+        )
+        contact_persons_to_delete = youth_data.pop(
+            "remove_additional_contact_persons", []
+        )
+
         youth_profile = YouthProfile.objects.get(approval_token=token)
 
         for field, value in youth_data.items():
             setattr(youth_profile, field, value)
+
+        # Additional contact persons
+        create_or_update_contact_persons(youth_profile, contact_persons_to_create)
+        create_or_update_contact_persons(youth_profile, contact_persons_to_update)
+        delete_contact_persons(youth_profile, contact_persons_to_delete)
 
         # try:
         #     # TODO Should get the profile email through other methods

--- a/youths/schema/mutations.py
+++ b/youths/schema/mutations.py
@@ -20,7 +20,7 @@ from ..utils import (
     create_or_update_contact_persons,
     delete_contact_persons,
 )
-from .types import LanguageAtHome, ProfileNode
+from .types import LanguageAtHome, YouthProfileNode
 
 # from django_ilmoitin.utils import send_notification
 # from ..enums import NotificationType
@@ -178,45 +178,52 @@ class YouthProfileFields(graphene.InputObjectType):
 
 
 # Subset of abstract fields are required for creation
-class CreateMyYouthProfileInput(YouthProfileFields):
+class CreateYouthProfileInput(YouthProfileFields):
     birth_date = graphene.Date(
         required=True,
         description="The youth's birth date. This is used for example to calculate if the youth is a minor or not.",
     )
 
 
+class UpdateYouthProfileInput(YouthProfileFields):
+    resend_request_notification = graphene.Boolean(
+        description="If set to `true`, a new approval token is generated and a new email notification is sent to the"
+        "approver's email address."
+    )
+
+
 class CreateYouthProfileMutation(relay.ClientIDMutation):
     class Input:
         id = graphene.Argument(graphene.ID, required=True)
-        profile = CreateMyYouthProfileInput(required=True)
+        youth_profile = CreateYouthProfileInput(required=True)
 
-    profile = graphene.Field(ProfileNode)
+    youth_profile = graphene.Field(YouthProfileNode)
 
     @classmethod
     @staff_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        input_data = input.get("profile")
+        input_data = input.get("youth_profile")
 
         # TODO Create youth profile with the given ID
         youth_profile = create_youth_profile(
             input_data, None, from_global_id(input.get("id"))[1]
         )
 
-        return CreateYouthProfileMutation(profile=youth_profile)
+        return CreateYouthProfileMutation(youth_profile=youth_profile)
 
 
 class CreateMyYouthProfileMutation(relay.ClientIDMutation):
     class Input:
-        profile = CreateMyYouthProfileInput(required=True)
+        youth_profile = CreateYouthProfileInput(required=True)
 
-    profile = graphene.Field(ProfileNode)
+    youth_profile = graphene.Field(YouthProfileNode)
 
     @classmethod
     @login_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        input_data = input.get("profile")
+        input_data = input.get("youth_profile")
 
         if calculate_age(input_data["birth_date"]) < 13:
             raise CannotCreateYouthProfileIfUnder13YearsOldError(
@@ -233,56 +240,51 @@ class CreateMyYouthProfileMutation(relay.ClientIDMutation):
         # TODO YM-287 Fetch profile ID from open-city-profile
         youth_profile = create_youth_profile(input_data, info.context.user)
 
-        return CreateMyYouthProfileMutation(profile=youth_profile)
-
-
-class UpdateYouthProfileInput(YouthProfileFields):
-    resend_request_notification = graphene.Boolean(
-        description="If set to `true`, a new approval token is generated and a new email notification is sent to the"
-        "approver's email address."
-    )
+        return CreateMyYouthProfileMutation(youth_profile=youth_profile)
 
 
 class UpdateYouthProfileMutation(relay.ClientIDMutation):
     class Input:
         id = graphene.Argument(graphene.ID, required=True)
-        profile = UpdateYouthProfileInput(required=True)
+        youth_profile = UpdateYouthProfileInput(required=True)
+
+    youth_profile = graphene.Field(YouthProfileNode)
 
     @classmethod
     @staff_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        input_data = input.get("profile")
+        input_data = input.get("youth_profile")
 
         youth_profile = YouthProfile.objects.get(pk=from_global_id(input.get("id"))[1])
         youth_profile = update_youth_profile(
             input_data, youth_profile, manage_permission=True
         )
-        return UpdateMyYouthProfileMutation(profile=youth_profile)
+        return UpdateYouthProfileMutation(youth_profile=youth_profile)
 
 
 class UpdateMyYouthProfileMutation(relay.ClientIDMutation):
     class Input:
-        profile = UpdateYouthProfileInput(required=True)
+        youth_profile = UpdateYouthProfileInput(required=True)
 
-    profile = graphene.Field(ProfileNode)
+    youth_profile = graphene.Field(YouthProfileNode)
 
     @classmethod
     @login_required
     @transaction.atomic
     def mutate_and_get_payload(cls, root, info, **input):
-        input_data = input.get("profile")
+        input_data = input.get("youth_profile")
 
         youth_profile = YouthProfile.objects.get(user=info.context.user)
         youth_profile = update_youth_profile(input_data, youth_profile)
-        return UpdateMyYouthProfileMutation(profile=youth_profile)
+        return UpdateMyYouthProfileMutation(youth_profile=youth_profile)
 
 
 class RenewYouthProfileMutation(relay.ClientIDMutation):
     class Input:
         id = graphene.Argument(graphene.ID, required=True)
 
-    profile = graphene.Field(ProfileNode)
+    youth_profile = graphene.Field(YouthProfileNode)
 
     @classmethod
     @staff_required
@@ -291,11 +293,11 @@ class RenewYouthProfileMutation(relay.ClientIDMutation):
         youth_profile = YouthProfile.objects.get(pk=from_global_id(input.get("id"))[1])
         youth_profile = renew_youth_profile(youth_profile)
 
-        return RenewYouthProfileMutation(profile=youth_profile)
+        return RenewYouthProfileMutation(youth_profile=youth_profile)
 
 
 class RenewMyYouthProfileMutation(relay.ClientIDMutation):
-    profile = graphene.Field(ProfileNode)
+    youth_profile = graphene.Field(YouthProfileNode)
 
     @classmethod
     @login_required
@@ -303,7 +305,7 @@ class RenewMyYouthProfileMutation(relay.ClientIDMutation):
     def mutate_and_get_payload(cls, root, info, **input):
         youth_profile = YouthProfile.objects.get(user=info.context.user)
         youth_profile = renew_youth_profile(youth_profile)
-        return RenewMyYouthProfileMutation(profile=youth_profile)
+        return RenewMyYouthProfileMutation(youth_profile=youth_profile)
 
 
 class ApproveYouthProfileMutation(relay.ClientIDMutation):
@@ -317,7 +319,7 @@ class ApproveYouthProfileMutation(relay.ClientIDMutation):
             description="The youth profile data to approve. This may contain modifications done by the approver.",
         )
 
-    profile = graphene.Field(ProfileNode)
+    youth_profile = graphene.Field(YouthProfileNode)
 
     @classmethod
     @transaction.atomic
@@ -348,7 +350,7 @@ class ApproveYouthProfileMutation(relay.ClientIDMutation):
         #     language=youth_profile.profile.language if youth_profile.profile else "fi",
         #     # TODO Refactor should get the language of profile through other methods
         # )
-        return ApproveYouthProfileMutation(profile=youth_profile)
+        return ApproveYouthProfileMutation(youth_profile=youth_profile)
 
 
 class CancelYouthProfileMutation(relay.ClientIDMutation):
@@ -360,7 +362,7 @@ class CancelYouthProfileMutation(relay.ClientIDMutation):
             description="Optional value for expiration. If missing or blank, current date will be used"
         )
 
-    profile = graphene.Field(ProfileNode)
+    youth_profile = graphene.Field(YouthProfileNode)
 
     @classmethod
     @staff_required
@@ -369,7 +371,7 @@ class CancelYouthProfileMutation(relay.ClientIDMutation):
         youth_profile = YouthProfile.objects.get(pk=from_global_id(input.get("id"))[1])
         youth_profile = cancel_youth_profile(youth_profile, input)
 
-        return CancelYouthProfileMutation(profile=youth_profile)
+        return CancelYouthProfileMutation(youth_profile=youth_profile)
 
 
 class CancelMyYouthProfileMutation(relay.ClientIDMutation):
@@ -378,7 +380,7 @@ class CancelMyYouthProfileMutation(relay.ClientIDMutation):
             description="Optional value for expiration. If missing or blank, current date will be used"
         )
 
-    profile = graphene.Field(ProfileNode)
+    youth_profile = graphene.Field(YouthProfileNode)
 
     @classmethod
     @login_required
@@ -388,7 +390,7 @@ class CancelMyYouthProfileMutation(relay.ClientIDMutation):
             YouthProfile.objects.get(user=info.context.user), input,
         )
 
-        return CancelMyYouthProfileMutation(profile=youth_profile)
+        return CancelMyYouthProfileMutation(youth_profile=youth_profile)
 
 
 class Mutation(graphene.ObjectType):

--- a/youths/schema/queries.py
+++ b/youths/schema/queries.py
@@ -4,25 +4,25 @@ from graphql_jwt.decorators import login_required
 
 from ..decorators import staff_required
 from ..models import YouthProfile
-from .types import ProfileNode
+from .types import YouthProfileNode
 
 
 class Query(graphene.ObjectType):
     # TODO: Add the complete list of error codes
     youth_profile = graphene.relay.Node.Field(
-        ProfileNode,
+        YouthProfileNode,
         description="Get a youth profile by youth profile ID.\n\nPossible error codes:\n\n* `TODO`",
     )
     # TODO: Add the complete list of error codes
     youth_profile_by_approval_token = graphene.Field(
-        ProfileNode,
+        YouthProfileNode,
         token=graphene.String(),
         description="Get a youth profile by approval token. \n\nDoesn't require authentication.\n\nPossible "
         "error codes:\n\n* `TODO`",
     )
     # TODO: Add the complete list of error codes
     youth_profiles = DjangoFilterConnectionField(
-        ProfileNode,
+        YouthProfileNode,
         description="Search for profiles. The results are filtered based on the given parameters. The results are "
         "paged using Relay.\n\nRequires `staff` credentials for the service given in "
         "`serviceType`. The profiles must have an active connection to the given `serviceType`, otherwise "
@@ -30,7 +30,7 @@ class Query(graphene.ObjectType):
     )
     # TODO: Add the complete list of error codes
     my_youth_profile = graphene.Field(
-        ProfileNode,
+        YouthProfileNode,
         description="Get the youth profile belonging to the currently authenticated user.\n\n"
         "Requires authentication.\n\nPossible error codes:\n\n* `TODO`",
     )

--- a/youths/schema/types.py
+++ b/youths/schema/types.py
@@ -30,6 +30,13 @@ MembershipStatusEnum = graphene.Enum.from_enum(
 class AdditionalContactPersonNode(DjangoObjectType):
     class Meta:
         model = AdditionalContactPerson
+        fields = (
+            "id",
+            "first_name",
+            "last_name",
+            "phone",
+            "email",
+        )
         interfaces = (relay.Node,)
 
 

--- a/youths/schema/types.py
+++ b/youths/schema/types.py
@@ -48,8 +48,7 @@ class ProfileFilter(django_filters.FilterSet):
     membership_number = django_filters.CharFilter(lookup_expr="icontains")
 
 
-@extend(fields="id")
-class ProfileNode(DjangoObjectType):
+class YouthProfileNode(DjangoObjectType):
     class Meta:
         model = YouthProfile
         fields = (
@@ -74,7 +73,10 @@ class ProfileNode(DjangoObjectType):
         filterset_class = ProfileFilter
         connection_class = CountConnection
 
-    id = external(relay.GlobalID())
+    profile = graphene.Field(
+        "youths.schema.types.ProfileNode",
+        description="Profile related to the youth profile",
+    )
 
     language_at_home = LanguageAtHome(
         description="The language which is spoken in the youth's home.", required=True,
@@ -92,6 +94,36 @@ class ProfileNode(DjangoObjectType):
         return bool(self.approved_time) and self.expiration != calculate_expiration(
             date.today()
         )
+
+    def resolve_profile(self: YouthProfile, info, **kwargs):
+        return self
+
+    @classmethod
+    @login_required
+    def get_node(cls, info, id):
+        node = super().get_node(info, id)
+        user = info.context.user
+        if user_is_admin(user) or node.user == user:
+            return node
+        return None
+
+
+@extend(fields="id")
+class ProfileNode(DjangoObjectType):
+    class Meta:
+        model = YouthProfile
+        fields = ("id",)
+        interfaces = (relay.Node,)
+        filterset_class = ProfileFilter
+        connection_class = CountConnection
+
+    id = external(relay.GlobalID())
+    youth_profile = graphene.Field(
+        YouthProfileNode, description="Youth Profile related to the Profile"
+    )
+
+    def resolve_youth_profile(self: YouthProfile, info, **kwargs):
+        return self
 
     @login_required
     def __resolve_reference(self, info, **kwargs):

--- a/youths/tests/test_graphql_api_additional_contact_persons.py
+++ b/youths/tests/test_graphql_api_additional_contact_persons.py
@@ -45,6 +45,17 @@ UPDATE_MUTATION = Template(
 )
 
 
+APPROVAL_MUTATION = Template(
+    """
+    mutation UpdateMyYouthProfile($$input: ApproveYouthProfileMutationInput!) {
+        approveYouthProfile(input: $$input) ${query}
+    }
+    """
+).substitute(
+    query=ADDITIONAL_CONTACT_PERSONS_QUERY_BASE.substitute(query_object="youthProfile")
+)
+
+
 def test_normal_user_can_add_additional_contact_persons(rf, user_gql_client):
     YouthProfileFactory(user=user_gql_client.user)
     acpd = AdditionalContactPersonDictFactory()
@@ -183,3 +194,49 @@ def test_normal_user_can_query_additional_contact_persons(
         }
     }
     assert dict(executed["data"]) == expected_data
+
+
+def test_profile_approval_allows_changing_contact_persons(
+    rf, anon_user_gql_client, youth_profile
+):
+    request = rf.post("/graphql")
+    request.user = anon_user_gql_client.user
+
+    acp_new_data = AdditionalContactPersonDictFactory()
+    acp_update = AdditionalContactPersonFactory(youth_profile=youth_profile)
+    acp_update_values = AdditionalContactPersonDictFactory()
+    acp_remove = AdditionalContactPersonFactory(youth_profile=youth_profile)
+
+    variables = {
+        "input": {
+            "approvalToken": youth_profile.approval_token,
+            "approvalData": {
+                "addAdditionalContactPersons": [acp_new_data],
+                "updateAdditionalContactPersons": [
+                    {
+                        "id": to_global_id(
+                            type="AdditionalContactPersonNode", id=acp_update.pk
+                        ),
+                        **acp_update_values,
+                    }
+                ],
+                "removeAdditionalContactPersons": [
+                    to_global_id(type="AdditionalContactPersonNode", id=acp_remove.pk)
+                ],
+            },
+        }
+    }
+
+    anon_user_gql_client.execute(
+        APPROVAL_MUTATION, context=request, variables=variables
+    )
+
+    assert not youth_profile.additional_contact_persons.filter(
+        pk=acp_remove.pk
+    ).exists()
+    assert youth_profile.additional_contact_persons.filter(
+        pk=acp_update.pk, first_name=acp_update_values["firstName"]
+    ).exists()
+    assert youth_profile.additional_contact_persons.exclude(
+        pk__in=[acp_update.pk, acp_remove.pk]
+    ).exists()

--- a/youths/tests/test_graphql_api_additional_contact_persons.py
+++ b/youths/tests/test_graphql_api_additional_contact_persons.py
@@ -41,7 +41,7 @@ UPDATE_MUTATION = Template(
     }
     """
 ).substitute(
-    query=ADDITIONAL_CONTACT_PERSONS_QUERY_BASE.substitute(query_object="profile")
+    query=ADDITIONAL_CONTACT_PERSONS_QUERY_BASE.substitute(query_object="youthProfile")
 )
 
 
@@ -51,7 +51,7 @@ def test_normal_user_can_add_additional_contact_persons(rf, user_gql_client):
     request = rf.post("/graphql")
     request.user = user_gql_client.user
 
-    variables = {"input": {"profile": {"addAdditionalContactPersons": [acpd]}}}
+    variables = {"input": {"youthProfile": {"addAdditionalContactPersons": [acpd]}}}
     executed = user_gql_client.execute(
         UPDATE_MUTATION, context=request, variables=variables
     )
@@ -59,7 +59,7 @@ def test_normal_user_can_add_additional_contact_persons(rf, user_gql_client):
     acp = AdditionalContactPerson.objects.first()
     expected_data = {
         "updateMyYouthProfile": {
-            "profile": {
+            "youthProfile": {
                 "additionalContactPersons": {
                     "edges": [
                         {
@@ -86,7 +86,7 @@ def test_normal_user_can_remove_additional_contact_persons(rf, user_gql_client):
 
     variables = {
         "input": {
-            "profile": {
+            "youthProfile": {
                 "removeAdditionalContactPersons": [
                     to_global_id(type="AdditionalContactPersonNode", id=acp.pk)
                 ]
@@ -98,7 +98,9 @@ def test_normal_user_can_remove_additional_contact_persons(rf, user_gql_client):
     )
 
     expected_data = {
-        "updateMyYouthProfile": {"profile": {"additionalContactPersons": {"edges": []}}}
+        "updateMyYouthProfile": {
+            "youthProfile": {"additionalContactPersons": {"edges": []}}
+        }
     }
     assert dict(executed["data"]) == expected_data
 
@@ -112,7 +114,7 @@ def test_normal_user_can_update_additional_contact_persons(rf, user_gql_client):
 
     variables = {
         "input": {
-            "profile": {
+            "youthProfile": {
                 "updateAdditionalContactPersons": [
                     {
                         "id": to_global_id(
@@ -130,7 +132,7 @@ def test_normal_user_can_update_additional_contact_persons(rf, user_gql_client):
 
     expected_data = {
         "updateMyYouthProfile": {
-            "profile": {
+            "youthProfile": {
                 "additionalContactPersons": {
                     "edges": [
                         {

--- a/youths/tests/test_graphql_federation.py
+++ b/youths/tests/test_graphql_federation.py
@@ -1,9 +1,27 @@
+from graphql_relay.node.node import to_global_id
+
+from youths.tests.factories import YouthProfileFactory
+
 FEDERATED_SCHEMA_QUERY = """
     {
         _service {
             sdl
         }
     }
+"""
+
+FEDERATED_PROFILES_QUERY = """
+query($_representations: [_Any!]!) {
+    _entities(representations: $_representations) {
+        ... on ProfileNode {
+            id
+            youthProfile {
+                id
+                membershipNumber
+            }
+        }
+    }
+}
 """
 
 
@@ -18,13 +36,37 @@ def test_profile_node_gets_extended_properly(rf, anon_user_gql_client):
     )
 
 
-def test_profile_connection_schema_matches_federated_schema(rf, anon_user_gql_client):
+def test_youth_profile_connection_schema_matches_federated_schema(
+    rf, anon_user_gql_client
+):
     request = rf.post("/graphql")
 
     executed = anon_user_gql_client.execute(FEDERATED_SCHEMA_QUERY, context=request)
 
     assert (
-        "type ProfileNodeConnection {   pageInfo: PageInfo!   "
-        "edges: [ProfileNodeEdge]!   count: Int!   totalCount: Int! }"
+        "type YouthProfileNodeConnection {   pageInfo: PageInfo!   "
+        "edges: [YouthProfileNodeEdge]!   count: Int!   totalCount: Int! }"
         in executed["data"]["_service"]["sdl"]
     )
+
+
+def test_query_extended_profile_nodes(rf, user_gql_client, youth_profile):
+    request = rf.post("/graphql")
+    request.user = user_gql_client.user
+    youth_profile = YouthProfileFactory(user=user_gql_client.user)
+
+    youth_profile_id = to_global_id("YouthProfileNode", youth_profile.id)
+    profile_id = to_global_id("ProfileNode", youth_profile.id)
+    variables = {"_representations": [{"id": profile_id, "__typename": "ProfileNode"}]}
+
+    executed = user_gql_client.execute(
+        FEDERATED_PROFILES_QUERY, variables=variables, context=request
+    )
+
+    assert executed["data"]["_entities"][0] == {
+        "id": profile_id,
+        "youthProfile": {
+            "id": youth_profile_id,
+            "membershipNumber": youth_profile.membership_number,
+        },
+    }

--- a/youths/tests/test_graphql_mutations.py
+++ b/youths/tests/test_graphql_mutations.py
@@ -25,7 +25,7 @@ def test_normal_user_can_create_youth_profile_mutation(rf, user_gql_client):
         mutation{
             createMyYouthProfile(
                 input: {
-                    profile: {
+                    youthProfile: {
                         schoolClass: "${schoolClass}"
                         schoolName: "${schoolName}"
                         languageAtHome: ${language}
@@ -36,7 +36,7 @@ def test_normal_user_can_create_youth_profile_mutation(rf, user_gql_client):
                 }
             )
             {
-                profile {
+                youthProfile {
                     schoolClass
                     schoolName
                     approverEmail
@@ -55,7 +55,7 @@ def test_normal_user_can_create_youth_profile_mutation(rf, user_gql_client):
     }
     query = t.substitute(**creation_data)
     expected_data = {
-        "profile": {
+        "youthProfile": {
             "schoolClass": creation_data["schoolClass"],
             "schoolName": creation_data["schoolName"],
             "approverEmail": creation_data["approverEmail"],
@@ -78,7 +78,7 @@ def test_normal_user_over_18_years_old_can_create_approved_youth_profile_mutatio
         mutation{
             createMyYouthProfile(
                 input: {
-                    profile: {
+                    youthProfile: {
                         schoolClass: "${schoolClass}"
                         schoolName: "${schoolName}"
                         birthDate: "${birthDate}"
@@ -87,7 +87,7 @@ def test_normal_user_over_18_years_old_can_create_approved_youth_profile_mutatio
                 }
             )
             {
-                profile {
+                youthProfile {
                     schoolClass
                     schoolName
                     birthDate
@@ -105,7 +105,7 @@ def test_normal_user_over_18_years_old_can_create_approved_youth_profile_mutatio
     }
     query = t.substitute(**creation_data)
     expected_data = {
-        "profile": {
+        "youthProfile": {
             "schoolClass": creation_data["schoolClass"],
             "schoolName": creation_data["schoolName"],
             "birthDate": creation_data["birthDate"],
@@ -128,14 +128,14 @@ def test_user_cannot_create_youth_profile_without_approver_email_field_if_under_
         mutation{
             createMyYouthProfile(
                 input: {
-                    profile: {
+                    youthProfile: {
                         birthDate: "${birthDate}"
                     }
 
                 }
             )
             {
-                profile {
+                youthProfile {
                     birthDate
                 }
             }
@@ -165,7 +165,7 @@ def test_user_cannot_create_youth_profile_if_under_13_years_old(rf, user_gql_cli
         mutation{
             createMyYouthProfile(
                 input: {
-                    profile: {
+                    youthProfile: {
                         schoolClass: "${schoolClass}"
                         schoolName: "${schoolName}"
                         languageAtHome: ${language}
@@ -176,7 +176,7 @@ def test_user_cannot_create_youth_profile_if_under_13_years_old(rf, user_gql_cli
                 }
             )
             {
-                profile {
+                youthProfile {
                     schoolClass
                     schoolName
                     approverEmail
@@ -215,7 +215,7 @@ def test_user_can_create_youth_profile_with_photo_usage_field_if_over_15_years_o
         mutation{
             createMyYouthProfile(
                 input: {
-                    profile: {
+                    youthProfile: {
                         photoUsageApproved: ${photoUsageApproved}
                         approverEmail: "${approverEmail}"
                         birthDate: "${birthDate}"
@@ -224,7 +224,7 @@ def test_user_can_create_youth_profile_with_photo_usage_field_if_over_15_years_o
                 }
             )
             {
-                profile {
+                youthProfile {
                     photoUsageApproved
                     approverEmail
                     birthDate
@@ -241,7 +241,7 @@ def test_user_can_create_youth_profile_with_photo_usage_field_if_over_15_years_o
     }
     query = t.substitute(**creation_data)
     expected_data = {
-        "profile": {
+        "youthProfile": {
             "photoUsageApproved": True,
             "approverEmail": creation_data["approverEmail"],
             "birthDate": creation_data["birthDate"],
@@ -263,7 +263,7 @@ def test_user_cannot_create_youth_profile_with_photo_usage_field_if_under_15_yea
         mutation{
             createMyYouthProfile(
                 input: {
-                    profile: {
+                    youthProfile: {
                         photoUsageApproved: ${photoUsageApproved}
                         approverEmail: "${approverEmail}"
                         birthDate: "${birthDate}"
@@ -272,7 +272,7 @@ def test_user_cannot_create_youth_profile_with_photo_usage_field_if_under_15_yea
                 }
             )
             {
-                profile {
+                youthProfile {
                     photoUsageApproved
                     approverEmail
                     birthDate
@@ -306,14 +306,14 @@ def test_normal_user_can_update_youth_profile_mutation(rf, user_gql_client):
         mutation{
             updateMyYouthProfile(
                 input: {
-                    profile: {
+                    youthProfile: {
                         schoolClass: "${schoolClass}"
                         birthDate: "${birthDate}"
                     }
                 }
             )
             {
-                profile {
+                youthProfile {
                     schoolClass
                     schoolName
                     birthDate
@@ -325,7 +325,7 @@ def test_normal_user_can_update_youth_profile_mutation(rf, user_gql_client):
     creation_data = {"schoolClass": "2A", "birthDate": "2002-02-02"}
     query = t.substitute(**creation_data)
     expected_data = {
-        "profile": {
+        "youthProfile": {
             "schoolClass": creation_data["schoolClass"],
             "schoolName": youth_profile.school_name,
             "birthDate": creation_data["birthDate"],
@@ -348,14 +348,14 @@ def test_user_can_update_youth_profile_with_photo_usage_field_if_over_15_years_o
         mutation{
             updateMyYouthProfile(
                 input: {
-                    profile: {
+                    youthProfile: {
                         photoUsageApproved: ${photoUsageApproved}
                         birthDate: "${birthDate}"
                     }
                 }
             )
             {
-                profile {
+                youthProfile {
                     photoUsageApproved
                     birthDate
                 }
@@ -370,7 +370,7 @@ def test_user_can_update_youth_profile_with_photo_usage_field_if_over_15_years_o
     }
     query = t.substitute(**creation_data)
     expected_data = {
-        "profile": {
+        "youthProfile": {
             "photoUsageApproved": True,
             "birthDate": creation_data["birthDate"],
         }
@@ -392,14 +392,14 @@ def test_user_cannot_update_youth_profile_with_photo_usage_field_if_under_15_yea
         mutation{
             updateMyYouthProfile(
                 input: {
-                    profile: {
+                    youthProfile: {
                         photoUsageApproved: ${photoUsageApproved}
                         birthDate: "${birthDate}"
                     }
                 }
             )
             {
-                profile {
+                youthProfile {
                     photoUsageApproved
                     birthDate
                 }
@@ -436,13 +436,13 @@ def test_user_can_update_youth_profile_with_photo_usage_field_if_over_15_years_o
         mutation{
             updateMyYouthProfile(
                 input: {
-                    profile: {
+                    youthProfile: {
                         photoUsageApproved: ${photoUsageApproved}
                     }
                 }
             )
             {
-                profile {
+                youthProfile {
                     photoUsageApproved
                 }
             }
@@ -451,7 +451,7 @@ def test_user_can_update_youth_profile_with_photo_usage_field_if_over_15_years_o
     )
     creation_data = {"photoUsageApproved": "true"}
     query = t.substitute(**creation_data)
-    expected_data = {"profile": {"photoUsageApproved": True}}
+    expected_data = {"youthProfile": {"photoUsageApproved": True}}
     executed = user_gql_client.execute(query, context=request)
     assert dict(executed["data"]["updateMyYouthProfile"]) == expected_data
 
@@ -471,13 +471,13 @@ def test_user_cannot_update_youth_profile_with_photo_usage_field_if_under_15_yea
         mutation{
             updateMyYouthProfile(
                 input: {
-                    profile: {
+                    youthProfile: {
                         photoUsageApproved: ${photoUsageApproved}
                     }
                 }
             )
             {
-                profile {
+                youthProfile {
                     photoUsageApproved
                 }
             }
@@ -511,24 +511,28 @@ def test_staff_user_can_update_youth_profile_with_photo_usage_field_if_under_15_
         mutation {
             updateYouthProfile(input:{
                 id: \"${id}\",
-                profile: {
+                youthProfile: {
                     photoUsageApproved: ${photo_usage_approved}
                 }
             }) {
-                clientMutationId
+                youthProfile {
+                    photoUsageApproved
+                }
             }
         }
     """
     )
     mutation = t.substitute(
-        id=to_global_id(type="ProfileNode", id=youth_profile.pk),
+        id=to_global_id(type="YouthProfileNode", id=youth_profile.pk),
         photo_usage_approved="true",
     )
     executed = staff_user_gql_client.execute(mutation, context=request)
 
+    expected_data = {"youthProfile": {"photoUsageApproved": True}}
     youth_profile.refresh_from_db()
     assert "errors" not in executed
     assert youth_profile.photo_usage_approved
+    assert dict(executed["data"]["updateYouthProfile"]) == expected_data
 
 
 def test_anon_user_can_approve_with_token(rf, anon_user_gql_client, youth_profile):
@@ -552,7 +556,7 @@ def test_anon_user_can_approve_with_token(rf, anon_user_gql_client, youth_profil
                 }
             )
             {
-                profile {
+                youthProfile {
                     photoUsageApproved
                     approverFirstName
                     approverLastName
@@ -574,7 +578,7 @@ def test_anon_user_can_approve_with_token(rf, anon_user_gql_client, youth_profil
     }
     query = t.substitute(**approval_data)
     expected_data = {
-        "profile": {
+        "youthProfile": {
             "photoUsageApproved": True,
             "approverFirstName": approval_data["approver_first_name"],
             "approverLastName": approval_data["approver_last_name"],
@@ -609,7 +613,7 @@ def test_missing_primary_email_error(rf, youth_profile, anon_user_gql_client):
                 }
             )
             {
-                profile {
+                youthProfile {
                     photoUsageApproved
                     approverFirstName
                     approverLastName
@@ -658,7 +662,7 @@ def test_youth_profile_expiration_should_renew_and_be_approvable(
         mutation = """
             mutation {
                 renewMyYouthProfile(input:{}) {
-                    profile {
+                    youthProfile {
                         membershipStatus
                     }
                 }
@@ -666,7 +670,7 @@ def test_youth_profile_expiration_should_renew_and_be_approvable(
         """
         executed = user_gql_client.execute(mutation, context=request)
         expected_data = {
-            "renewMyYouthProfile": {"profile": {"membershipStatus": "RENEWING"}}
+            "renewMyYouthProfile": {"youthProfile": {"membershipStatus": "RENEWING"}}
         }
         assert dict(executed["data"]) == expected_data
 
@@ -697,7 +701,7 @@ def test_youth_profile_expiration_should_renew_and_be_approvable(
                     }
                 )
                 {
-                    profile {
+                    youthProfile {
                         membershipStatus
                     }
                 }
@@ -708,7 +712,7 @@ def test_youth_profile_expiration_should_renew_and_be_approvable(
         approval_data = {"token": youth_profile.approval_token}
         query = t.substitute(**approval_data)
         expected_data = {
-            "approveYouthProfile": {"profile": {"membershipStatus": "ACTIVE"}}
+            "approveYouthProfile": {"youthProfile": {"membershipStatus": "ACTIVE"}}
         }
         executed = anon_user_gql_client.execute(query, context=request)
         assert dict(executed["data"]) == expected_data
@@ -738,7 +742,7 @@ def test_youth_profile_expiration_should_be_renewable_by_staff_user(
                 renewYouthProfile(input:{
                     id: \"${id}\"
                 }) {
-                    profile {
+                    youthProfile {
                         membershipStatus
                     }
                 }
@@ -746,12 +750,12 @@ def test_youth_profile_expiration_should_be_renewable_by_staff_user(
         """
         )
         mutation = t.substitute(
-            id=to_global_id(type="ProfileNode", id=youth_profile.pk),
+            id=to_global_id(type="YouthProfileNode", id=youth_profile.pk),
         )
 
         executed = staff_user_gql_client.execute(mutation, context=request)
         expected_data = {
-            "renewYouthProfile": {"profile": {"membershipStatus": "RENEWING"}}
+            "renewYouthProfile": {"youthProfile": {"membershipStatus": "RENEWING"}}
         }
         assert dict(executed["data"]) == expected_data
 
@@ -769,7 +773,7 @@ def test_youth_profile_expiration_should_be_renewable_by_staff_user(
                     }
                 )
                 {
-                    profile {
+                    youthProfile {
                         membershipStatus
                     }
                 }
@@ -780,7 +784,7 @@ def test_youth_profile_expiration_should_be_renewable_by_staff_user(
         approval_data = {"token": youth_profile.approval_token}
         query = t.substitute(**approval_data)
         expected_data = {
-            "approveYouthProfile": {"profile": {"membershipStatus": "ACTIVE"}}
+            "approveYouthProfile": {"youthProfile": {"membershipStatus": "ACTIVE"}}
         }
         executed = anon_user_gql_client.execute(query, context=request)
         assert dict(executed["data"]) == expected_data
@@ -806,7 +810,7 @@ def test_youth_profile_expiration_for_over_18_years_old_should_renew_and_change_
         mutation = """
             mutation {
                 renewMyYouthProfile(input:{}) {
-                    profile {
+                    youthProfile {
                         membershipStatus
                     }
                 }
@@ -814,7 +818,7 @@ def test_youth_profile_expiration_for_over_18_years_old_should_renew_and_change_
         """
         executed = user_gql_client.execute(mutation, context=request)
         expected_data = {
-            "renewMyYouthProfile": {"profile": {"membershipStatus": "ACTIVE"}}
+            "renewMyYouthProfile": {"youthProfile": {"membershipStatus": "ACTIVE"}}
         }
         assert dict(executed["data"]) == expected_data
 
@@ -853,7 +857,7 @@ def test_should_not_be_able_to_renew_pending_youth_profile(rf, user_gql_client):
         mutation = """
             mutation {
                 renewMyYouthProfile(input:{}) {
-                    profile {
+                    youthProfile {
                         membershipStatus
                     }
                 }
@@ -870,7 +874,7 @@ def test_staff_user_can_create_youth_profile(rf, staff_user_gql_client):
     user = staff_user_gql_client.user
 
     # TODO mock profile_id query from open-city-profile, YM-287
-    profile_id = to_global_id(type="ProfileNode", id=str(uuid.uuid4()))
+    profile_id = to_global_id(type="YouthProfileNode", id=str(uuid.uuid4()))
     request = rf.post("/graphql")
     request.user = user
     today = date.today()
@@ -892,7 +896,7 @@ def test_staff_user_can_create_youth_profile(rf, staff_user_gql_client):
             createYouthProfile(
                 input: {
                     id: \"${id}\",
-                    profile: {
+                    youthProfile: {
                         birthDate: \"${birth_date}\",
                         schoolName: \"${school_name}\",
                         schoolClass: \"${school_class}\",
@@ -904,7 +908,7 @@ def test_staff_user_can_create_youth_profile(rf, staff_user_gql_client):
                     }
                 }
             ) {
-                profile {
+                youthProfile {
                     id
                     birthDate
                     schoolName
@@ -932,7 +936,7 @@ def test_staff_user_can_create_youth_profile(rf, staff_user_gql_client):
     )
     expected_data = {
         "createYouthProfile": {
-            "profile": {
+            "youthProfile": {
                 "id": profile_id,
                 "birthDate": youth_profile_data["birth_date"],
                 "schoolName": youth_profile_data["school_name"],
@@ -953,7 +957,7 @@ def test_staff_user_can_create_youth_profile_for_under_13_years_old(
     rf, staff_user_gql_client
 ):
     # TODO mock profile_id query from open-city-profile, YM-287
-    profile_id = to_global_id(type="ProfileNode", id=str(uuid.uuid4()))
+    profile_id = to_global_id(type="YouthProfileNode", id=str(uuid.uuid4()))
 
     user = staff_user_gql_client.user
     request = rf.post("/graphql")
@@ -972,13 +976,13 @@ def test_staff_user_can_create_youth_profile_for_under_13_years_old(
             createYouthProfile(
                 input: {
                     id: \"${id}\",
-                    profile: {
+                    youthProfile: {
                         birthDate: \"${birth_date}\",
                         approverEmail: \"${approver_email}\",
                     }
                 }
             ) {
-                profile {
+                youthProfile {
                     id
                     birthDate
                     approverEmail
@@ -994,7 +998,7 @@ def test_staff_user_can_create_youth_profile_for_under_13_years_old(
     )
     expected_data = {
         "createYouthProfile": {
-            "profile": {
+            "youthProfile": {
                 "id": profile_id,
                 "birthDate": youth_profile_data["birth_date"],
                 "approverEmail": youth_profile_data["approver_email"],
@@ -1026,13 +1030,13 @@ def test_normal_user_cannot_use_create_youth_profile_mutation(rf, user_gql_clien
             createYouthProfile(
                 input: {
                     id: \"${id}\",
-                    profile: {
+                    youthProfile: {
                         birthDate: \"${birth_date}\",
                         approverEmail: \"${approver_email}\",
                     }
                 }
             ) {
-                profile {
+                youthProfile {
                     id
                     birthDate
                     approverEmail
@@ -1042,7 +1046,7 @@ def test_normal_user_cannot_use_create_youth_profile_mutation(rf, user_gql_clien
     """
     )
     query = t.substitute(
-        id=to_global_id(type="ProfileNode", id=profile_id),
+        id=to_global_id(type="YouthProfileNode", id=profile_id),
         birth_date=youth_profile_data["birth_date"],
         approver_email=youth_profile_data["approver_email"],
     )
@@ -1062,7 +1066,7 @@ def test_staff_user_can_cancel_youth_membership_on_selected_date(
     today = date.today()
     expiration_date = today + timedelta(days=1)
     youth_profile_data = {
-        "id": to_global_id(type="ProfileNode", id=youth_profile.pk),
+        "id": to_global_id(type="YouthProfileNode", id=youth_profile.pk),
         "expiration": expiration_date.strftime("%Y-%m-%d"),
     }
 
@@ -1075,7 +1079,7 @@ def test_staff_user_can_cancel_youth_membership_on_selected_date(
                     expiration: \"${expiration}\"
                 }
             ) {
-                profile {
+                youthProfile {
                     expiration
                 }
             }
@@ -1087,7 +1091,7 @@ def test_staff_user_can_cancel_youth_membership_on_selected_date(
     )
     expected_data = {
         "cancelYouthProfile": {
-            "profile": {"expiration": youth_profile_data["expiration"]}
+            "youthProfile": {"expiration": youth_profile_data["expiration"]}
         }
     }
     executed = staff_user_gql_client.execute(query, context=request)
@@ -1109,17 +1113,17 @@ def test_staff_user_can_cancel_youth_membership_now(
                     id: \"${id}\",
                 }
             ) {
-                profile {
+                youthProfile {
                     expiration
                 }
             }
         }
     """
     )
-    query = t.substitute(id=to_global_id(type="ProfileNode", id=youth_profile.pk))
+    query = t.substitute(id=to_global_id(type="YouthProfileNode", id=youth_profile.pk))
     expected_data = {
         "cancelYouthProfile": {
-            "profile": {"expiration": date.today().strftime("%Y-%m-%d")}
+            "youthProfile": {"expiration": date.today().strftime("%Y-%m-%d")}
         }
     }
     executed = staff_user_gql_client.execute(query, context=request)
@@ -1144,7 +1148,7 @@ def test_normal_user_can_cancel_youth_membership(rf, user_gql_client):
                 }
             )
             {
-                profile {
+                youthProfile {
                     expiration
                     membershipStatus
                 }
@@ -1155,7 +1159,7 @@ def test_normal_user_can_cancel_youth_membership(rf, user_gql_client):
     query = t.substitute(expiration=expiration_string)
 
     expected_data = {
-        "profile": {"expiration": expiration_string, "membershipStatus": "EXPIRED"}
+        "youthProfile": {"expiration": expiration_string, "membershipStatus": "EXPIRED"}
     }
     executed = user_gql_client.execute(query, context=request)
     assert dict(executed["data"]["cancelMyYouthProfile"]) == expected_data
@@ -1172,7 +1176,7 @@ def test_normal_user_can_cancel_youth_membership_now(rf, user_gql_client):
                 input: {}
             )
             {
-                profile {
+                youthProfile {
                     expiration
                     membershipStatus
                 }
@@ -1180,7 +1184,7 @@ def test_normal_user_can_cancel_youth_membership_now(rf, user_gql_client):
         }
     """
     expected_data = {
-        "profile": {
+        "youthProfile": {
             "expiration": date.today().strftime("%Y-%m-%d"),
             "membershipStatus": "EXPIRED",
         }

--- a/youths/tests/test_graphql_queries.py
+++ b/youths/tests/test_graphql_queries.py
@@ -30,9 +30,11 @@ def test_anon_user_query_should_fail(
         """
     )
     if use_proper_profile_id:
-        query = t.substitute(id=to_global_id(type="ProfileNode", id=youth_profile.pk))
+        query = t.substitute(
+            id=to_global_id(type="YouthProfileNode", id=youth_profile.pk)
+        )
     else:
-        query = t.substitute(id=to_global_id(type="ProfileNode", id=uuid.uuid4()))
+        query = t.substitute(id=to_global_id(type="YouthProfileNode", id=uuid.uuid4()))
     expected_data = {"youthProfile": None}
     executed = anon_user_gql_client.execute(query, context=request)
     assert dict(executed["data"]) == expected_data
@@ -62,7 +64,7 @@ def test_querying_non_existant_profile_returns_none(rf, gql_client):
         }
         """
     )
-    query = t.substitute(id=to_global_id(type="ProfileNode", id=uuid.uuid4()))
+    query = t.substitute(id=to_global_id(type="YouthProfileNode", id=uuid.uuid4()))
     expected_data = {"youthProfile": None}
     executed = gql_client.execute(query, context=request)
     assert dict(executed["data"]) == expected_data
@@ -72,7 +74,7 @@ def test_normal_user_can_query_own_youth_profile_by_id(rf, user_gql_client):
     request = rf.post("/graphql")
     request.user = user_gql_client.user
     youth_profile = YouthProfileFactory(user=user_gql_client.user)
-    profile_id = to_global_id(type="ProfileNode", id=youth_profile.pk)
+    profile_id = to_global_id(type="YouthProfileNode", id=youth_profile.pk)
     t = Template(
         """
         {
@@ -102,7 +104,7 @@ def test_normal_user_cannot_query_someone_elses_youth_profile_by_id(
     request = rf.post("/graphql")
     request.user = user_gql_client.user
     youth_profile = YouthProfileFactory()
-    profile_id = to_global_id(type="ProfileNode", id=youth_profile.pk)
+    profile_id = to_global_id(type="YouthProfileNode", id=youth_profile.pk)
 
     t = Template(
         """
@@ -137,7 +139,7 @@ def test_normal_user_can_query_my_youth_profile(rf, user_gql_client):
     """
     expected_data = {
         "myYouthProfile": {
-            "id": to_global_id(type="ProfileNode", id=youth_profile.pk),
+            "id": to_global_id(type="YouthProfileNode", id=youth_profile.pk),
             "schoolClass": youth_profile.school_class,
             "membershipNumber": youth_profile.membership_number,
         }
@@ -156,7 +158,7 @@ def test_normal_user_can_query_my_youth_profile(rf, user_gql_client):
 def test_staff_user_can_query_own_youth_profile_by_id(rf, youth_profile, gql_client):
     request = rf.post("/graphql")
     request.user = gql_client.user
-    profile_id = to_global_id(type="ProfileNode", id=youth_profile.pk)
+    profile_id = to_global_id(type="YouthProfileNode", id=youth_profile.pk)
 
     t = Template(
         """


### PR DESCRIPTION
This PR refactors the youth profile GQL API to have `ProfileNode` and `YouthProfileNode` types instead of just the former. 

`ProfileNode` extends the `ProfileNode` in open-city-profile by adding just one non-required extra field for youth profile. This will allow the `YouthProfileNode` type itself to have fields that are required. There would've been some federation related issues if the fields in `YouthProfileNode` would've been added straight to the `ProfileNode` type.

All normal queries and mutations in the GQL API return `YouthProfileNode` objects. Extended `ProfileNode` is there only for allowing the API to federated Apollo federation gateway.