### PR TITLE
YM-417 YM-418 | Fetch additional information for youth membership approval and confirmation messages

### DIFF
--- a/common_utils/profile.py
+++ b/common_utils/profile.py
@@ -78,6 +78,8 @@ class ProfileAPI:
             query myProfile {
                 myProfile {
                     id
+                    firstName
+                    lastName
                 }
             }
         """
@@ -85,6 +87,8 @@ class ProfileAPI:
             """
             data.myProfile.{
                 id: id
+                first_name: firstName
+                last_name: lastName
             }
         """
         )
@@ -92,7 +96,7 @@ class ProfileAPI:
         data = self.do_query(api_token, query)
 
         parsed_data = path.search(data)
-        self.contains_keys(parsed_data, ["id"])
+        self.contains_keys(parsed_data, ["id", "first_name", "last_name"])
         return parsed_data
 
     def create_temporary_access_token(self, api_token: str) -> dict:

--- a/common_utils/tests/conftest.py
+++ b/common_utils/tests/conftest.py
@@ -6,14 +6,22 @@ from youth_membership.tests.conftest import *  # noqa
 
 @pytest.fixture(scope="session")
 def my_profile_response():
+    """ProfileNode:5b36406d-da95-4cb0-88d8-2ec6f80e9fc9"""
     return read_json_file(__file__, "responses", "my_profile_response.json")
 
 
 @pytest.fixture(scope="session")
 def profile_response():
+    """ProfileNode:5b36406d-da95-4cb0-88d8-2ec6f80e9fc9"""
     return read_json_file(__file__, "responses", "profile_response.json")
 
 
 @pytest.fixture(scope="session")
 def temporary_token_response():
     return read_json_file(__file__, "responses", "temporary_token_response.json")
+
+
+@pytest.fixture(scope="session")
+def profile_access_token_response():
+    """RestrictedProfileNode:5b36406d-da95-4cb0-88d8-2ec6f80e9fc9"""
+    return read_json_file(__file__, "responses", "profile_access_token_response.json")

--- a/common_utils/tests/responses/my_profile_response.json
+++ b/common_utils/tests/responses/my_profile_response.json
@@ -1,7 +1,9 @@
 {
   "data": {
     "myProfile": {
-      "id": "UHJvZmlsZU5vZGU6NWIzNjQwNmQtZGE5NS00Y2IwLTg4ZDgtMmVjNmY4MGU5ZmM5"
+      "id": "UHJvZmlsZU5vZGU6NWIzNjQwNmQtZGE5NS00Y2IwLTg4ZDgtMmVjNmY4MGU5ZmM5",
+      "firstName": "Test",
+      "lastName": "Person"
     }
   }
 }

--- a/common_utils/tests/responses/profile_access_token_response.json
+++ b/common_utils/tests/responses/profile_access_token_response.json
@@ -1,0 +1,12 @@
+{
+    "data": {
+        "profileWithAccessToken": {
+            "id": "UmVzdHJpY3RlZFByb2ZpbGVOb2RlOjViMzY0MDZkLWRhOTUtNGNiMC04OGQ4LTJlYzZmODBlOWZjOQ==",
+            "firstName": "Test",
+            "lastName": "Person",
+            "primaryEmail": {
+                "email": "testi@example.com"
+            }
+        }
+    }
+}

--- a/common_utils/tests/test_profile_gql_queries.py
+++ b/common_utils/tests/test_profile_gql_queries.py
@@ -11,6 +11,12 @@ PROFILE_ID = "UHJvZmlsZU5vZGU6NWIzNjQwNmQtZGE5NS00Y2IwLTg4ZDgtMmVjNmY4MGU5ZmM5"
 FIRST_NAME = "Test"
 LAST_NAME = "Person"
 
+# RestrictedProfileNode:5b36406d-da95-4cb0-88d8-2ec6f80e9fc9
+RESTRICTED_PROFILE_ID = (
+    "UmVzdHJpY3RlZFByb2ZpbGVOb2RlOjViMzY0MDZkLWRhOTUtNGNiMC04OGQ4LTJlYzZmODBlOWZjOQ=="
+)
+EMAIL = "testi@example.com"
+
 
 def test_call_profile_api_and_fetch_my_profile(
     requests_mock, my_profile_response, settings
@@ -61,4 +67,23 @@ def test_create_my_profile_temporary_read_access_token(
     profile = api.create_temporary_access_token("api_token")
 
     expected_data = {"token": token, "expires_at": expires_at}
+    assert profile == expected_data
+
+
+def test_fetch_profile_with_temporary_access_token(
+    requests_mock, profile_access_token_response, settings
+):
+    requests_mock.post(
+        settings.HELSINKI_PROFILE_API_URL, json=profile_access_token_response
+    )
+    api = ProfileAPI()
+
+    profile = api.fetch_profile_with_temporary_access_token("token")
+
+    expected_data = {
+        "id": RESTRICTED_PROFILE_ID,
+        "first_name": FIRST_NAME,
+        "last_name": LAST_NAME,
+        "email": EMAIL,
+    }
     assert profile == expected_data

--- a/common_utils/tests/test_profile_gql_queries.py
+++ b/common_utils/tests/test_profile_gql_queries.py
@@ -8,6 +8,8 @@ from common_utils.profile import ProfileAPI
 
 # ID in the mocked responses ProfileNode:5b36406d-da95-4cb0-88d8-2ec6f80e9fc9
 PROFILE_ID = "UHJvZmlsZU5vZGU6NWIzNjQwNmQtZGE5NS00Y2IwLTg4ZDgtMmVjNmY4MGU5ZmM5"
+FIRST_NAME = "Test"
+LAST_NAME = "Person"
 
 
 def test_call_profile_api_and_fetch_my_profile(
@@ -18,7 +20,11 @@ def test_call_profile_api_and_fetch_my_profile(
 
     profile = api.fetch_my_profile("api_token")
 
-    expected_data = {"id": PROFILE_ID}
+    expected_data = {
+        "id": PROFILE_ID,
+        "first_name": FIRST_NAME,
+        "last_name": LAST_NAME,
+    }
     assert profile == expected_data
 
 

--- a/youths/models.py
+++ b/youths/models.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import asdict
 from datetime import date
 
 import reversion
@@ -14,6 +15,7 @@ from common_utils.models import SerializableMixin, UUIDModel
 
 from .enums import MembershipStatus, NotificationType
 from .enums import YouthLanguage as LanguageAtHome
+from .notifications import ConfirmationMessageExtraContext
 
 
 def calculate_expiration(from_date=None):
@@ -75,12 +77,12 @@ class YouthProfile(UUIDModel, SerializableMixin):
     # Source sequence of integer values for a membership number.
     membership_number_sequence = Sequence("membership_number")
 
-    def make_approvable(self):
+    def make_approvable(self, extra_context: ConfirmationMessageExtraContext):
         self.approval_token = uuid.uuid4()
         send_notification(
             email=self.approver_email,
             notification_type=NotificationType.YOUTH_PROFILE_CONFIRMATION_NEEDED.value,
-            context={"youth_profile": self},
+            context={"youth_profile": self, **asdict(extra_context)},
             language=self.language_at_home.value,
         )
         self.approval_notification_timestamp = timezone.now()

--- a/youths/models.py
+++ b/youths/models.py
@@ -1,5 +1,4 @@
 import uuid
-from dataclasses import asdict
 from datetime import date
 
 import reversion
@@ -15,7 +14,6 @@ from common_utils.models import SerializableMixin, UUIDModel
 
 from .enums import MembershipStatus, NotificationType
 from .enums import YouthLanguage as LanguageAtHome
-from .notifications import ConfirmationMessageExtraContext
 
 
 def calculate_expiration(from_date=None):
@@ -77,12 +75,12 @@ class YouthProfile(UUIDModel, SerializableMixin):
     # Source sequence of integer values for a membership number.
     membership_number_sequence = Sequence("membership_number")
 
-    def make_approvable(self, extra_context: ConfirmationMessageExtraContext):
+    def make_approvable(self, youth_name: str):
         self.approval_token = uuid.uuid4()
         send_notification(
             email=self.approver_email,
             notification_type=NotificationType.YOUTH_PROFILE_CONFIRMATION_NEEDED.value,
-            context={"youth_profile": self, **asdict(extra_context)},
+            context={"youth_profile": self, "youth_name": youth_name},
             language=self.language_at_home.value,
         )
         self.approval_notification_timestamp = timezone.now()

--- a/youths/notifications.py
+++ b/youths/notifications.py
@@ -1,15 +1,7 @@
-from dataclasses import dataclass
-
 from django_ilmoitin.dummy_context import COMMON_CONTEXT, dummy_context
 from django_ilmoitin.registry import notifications
 
 from .enums import NotificationType
-
-
-@dataclass
-class ConfirmationMessageExtraContext:
-    youth_name: str
-
 
 notifications.register(
     NotificationType.YOUTH_PROFILE_CONFIRMATION_NEEDED.value,

--- a/youths/notifications.py
+++ b/youths/notifications.py
@@ -1,4 +1,4 @@
-from django_ilmoitin.dummy_context import dummy_context
+from django_ilmoitin.dummy_context import COMMON_CONTEXT, dummy_context
 from django_ilmoitin.registry import notifications
 
 from .enums import NotificationType
@@ -12,4 +12,19 @@ notifications.register(
     NotificationType.YOUTH_PROFILE_CONFIRMED.label,
 )
 
-dummy_context.context.update({"youth_profile": None})
+
+dummy_context.update(
+    {
+        COMMON_CONTEXT: {
+            "youth_name": "YOUTH NAME",
+            "youth_profile": {"approver_first_name": "APPROVER FIRST NAME"},
+        },
+        NotificationType.YOUTH_PROFILE_CONFIRMATION_NEEDED.value: {
+            "youth_profile": {
+                "approver_first_name": "APPROVER FIRST NAME",
+                "approval_token": "approval_token",
+                "profile_access_token": "profile_access_token",
+            }
+        },
+    }
+)

--- a/youths/notifications.py
+++ b/youths/notifications.py
@@ -1,7 +1,15 @@
+from dataclasses import dataclass
+
 from django_ilmoitin.dummy_context import COMMON_CONTEXT, dummy_context
 from django_ilmoitin.registry import notifications
 
 from .enums import NotificationType
+
+
+@dataclass
+class ConfirmationMessageExtraContext:
+    youth_name: str
+
 
 notifications.register(
     NotificationType.YOUTH_PROFILE_CONFIRMATION_NEEDED.value,

--- a/youths/schema/mutations.py
+++ b/youths/schema/mutations.py
@@ -2,15 +2,22 @@ from datetime import date
 
 import graphene
 from django.db import transaction
+from django.utils import timezone
+from django_ilmoitin.utils import send_notification
 from graphene import relay
 from graphql import GraphQLError
 from graphql_jwt.decorators import login_required
 from graphql_relay.node.node import from_global_id, to_global_id
 
-from common_utils.exceptions import ProfileDoesNotExistError
+from common_utils.exceptions import (
+    ProfileDoesNotExistError,
+    ProfileHasNoPrimaryEmailError,
+    TokenExpiredError,
+)
 from common_utils.profile import ProfileAPI
 
 from ..decorators import staff_required
+from ..enums import NotificationType
 from ..exceptions import (
     ApproverEmailCannotBeEmptyForMinorsError,
     CannotCreateYouthProfileIfUnder13YearsOldError,
@@ -18,7 +25,6 @@ from ..exceptions import (
     CannotSetPhotoUsagePermissionIfUnder15YearsError,
 )
 from ..models import calculate_expiration, YouthProfile
-from ..notifications import ConfirmationMessageExtraContext
 from ..utils import (
     calculate_age,
     create_or_update_contact_persons,
@@ -251,10 +257,7 @@ class CreateMyYouthProfileMutation(relay.ClientIDMutation):
                     "Approver email is required for youth under 18 years old"
                 )
             generate_profile_access_token(profile_api_token, youth_profile)
-            extra_context = ConfirmationMessageExtraContext(
-                youth_name=profile_data["first_name"]
-            )
-            youth_profile.make_approvable(extra_context=extra_context)
+            youth_profile.make_approvable(youth_name=profile_data["first_name"])
         youth_profile.save()
 
         return CreateMyYouthProfileMutation(youth_profile=youth_profile)
@@ -307,10 +310,7 @@ class UpdateMyYouthProfileMutation(relay.ClientIDMutation):
             profile_api = ProfileAPI()
             profile_data = profile_api.fetch_my_profile(profile_api_token)
             generate_profile_access_token(profile_api_token, youth_profile)
-            extra_context = ConfirmationMessageExtraContext(
-                youth_name=profile_data["first_name"]
-            )
-            youth_profile.make_approvable(extra_context=extra_context)
+            youth_profile.make_approvable(youth_name=profile_data["first_name"])
             youth_profile.save()
 
         return UpdateMyYouthProfileMutation(youth_profile=youth_profile)
@@ -356,10 +356,7 @@ class RenewMyYouthProfileMutation(relay.ClientIDMutation):
             profile_api = ProfileAPI()
             profile_data = profile_api.fetch_my_profile(profile_api_token)
             generate_profile_access_token(profile_api_token, youth_profile)
-            extra_context = ConfirmationMessageExtraContext(
-                youth_name=profile_data["first_name"]
-            )
-            youth_profile.make_approvable(extra_context=extra_context)
+            youth_profile.make_approvable(youth_name=profile_data["first_name"])
         youth_profile.save()
 
         return RenewMyYouthProfileMutation(youth_profile=youth_profile)
@@ -383,9 +380,23 @@ class ApproveYouthProfileMutation(relay.ClientIDMutation):
     def mutate_and_get_payload(cls, root, info, **input):
         youth_data = input.get("approval_data")
         token = input.get("approval_token")
-
         if not token:
             raise GraphQLError("Approval token cannot be empty.")
+        youth_profile = YouthProfile.objects.get(approval_token=token)
+        if (
+            not youth_profile.profile_access_token
+            or youth_profile.profile_access_token_expiration < timezone.now()
+        ):
+            raise TokenExpiredError("Profile access token is expired or not set.")
+
+        profile_api = ProfileAPI()
+        profile_data = profile_api.fetch_profile_with_temporary_access_token(
+            youth_profile.profile_access_token
+        )
+        if not profile_data["email"]:
+            raise ProfileHasNoPrimaryEmailError(
+                "Cannot send email confirmation, youth profile has no primary email address."
+            )
 
         contact_persons_to_create = youth_data.pop("add_additional_contact_persons", [])
         contact_persons_to_update = youth_data.pop(
@@ -395,8 +406,6 @@ class ApproveYouthProfileMutation(relay.ClientIDMutation):
             "remove_additional_contact_persons", []
         )
 
-        youth_profile = YouthProfile.objects.get(approval_token=token)
-
         for field, value in youth_data.items():
             setattr(youth_profile, field, value)
 
@@ -405,23 +414,18 @@ class ApproveYouthProfileMutation(relay.ClientIDMutation):
         create_or_update_contact_persons(youth_profile, contact_persons_to_update)
         delete_contact_persons(youth_profile, contact_persons_to_delete)
 
-        # try:
-        #     # TODO Should get the profile email through other methods
-        #     email = youth_profile.profile.get_primary_email()
-        # except Email.DoesNotExist:
-        #     raise ProfileHasNoPrimaryEmailError(
-        #         "Cannot send email confirmation, youth profile has no primary email address."
-        #     )
-
         youth_profile.set_approved()
         youth_profile.save()
-        # send_notification(
-        #     email=email.email,
-        #     notification_type=NotificationType.YOUTH_PROFILE_CONFIRMED.value,
-        #     context={"youth_profile": youth_profile},
-        #     language=youth_profile.profile.language if youth_profile.profile else "fi",
-        #     # TODO Refactor should get the language of profile through other methods
-        # )
+
+        send_notification(
+            email=profile_data["email"],
+            notification_type=NotificationType.YOUTH_PROFILE_CONFIRMED.value,
+            context={
+                "youth_profile": youth_profile,
+                "youth_name": profile_data["first_name"],
+            },
+            language=youth_profile.language_at_home.value,
+        )
         return ApproveYouthProfileMutation(youth_profile=youth_profile)
 
 

--- a/youths/tests/conftest.py
+++ b/youths/tests/conftest.py
@@ -6,6 +6,7 @@ from youths.tests.factories import (
     MyProfileAPIResponse,
     ProfileAPIResponse,
     ProfileAPITokenResponse,
+    RestrictedProfileAPIResponse,
     YouthProfileFactory,
 )
 
@@ -44,3 +45,8 @@ def my_profile_api_response():
 @pytest.fixture
 def token_response():
     return ProfileAPITokenResponse()
+
+
+@pytest.fixture
+def restricted_profile_response():
+    return RestrictedProfileAPIResponse()

--- a/youths/tests/conftest.py
+++ b/youths/tests/conftest.py
@@ -3,6 +3,7 @@ from rest_framework.test import APIClient
 
 from youth_membership.tests.conftest import *  # noqa
 from youths.tests.factories import (
+    MyProfileAPIResponse,
     ProfileAPIResponse,
     ProfileAPITokenResponse,
     YouthProfileFactory,
@@ -33,6 +34,11 @@ def setup_gdpr_api(settings):
 @pytest.fixture
 def profile_api_response():
     return ProfileAPIResponse()
+
+
+@pytest.fixture
+def my_profile_api_response():
+    return MyProfileAPIResponse()
 
 
 @pytest.fixture

--- a/youths/tests/factories.py
+++ b/youths/tests/factories.py
@@ -10,10 +10,21 @@ from youths.models import AdditionalContactPerson, YouthProfile
 
 
 class ProfileAPIResponse(factory.DictFactory):
+    """Data returned from ProfileAPI.fetch_profile."""
+
     id = factory.Faker("uuid4", cast_to=partial(to_global_id, "ProfileNode"))
 
 
+class MyProfileAPIResponse(ProfileAPIResponse):
+    """Data returned from ProfileAPI.fetch_my_profile."""
+
+    first_name = factory.Faker("first_name")
+    last_name = factory.Faker("last_name")
+
+
 class ProfileAPITokenResponse(factory.DictFactory):
+    """Data returned from ProfileAPI.create_temporary_access_token."""
+
     token = factory.Faker("uuid4", cast_to=str)
     expires_at = factory.LazyFunction(
         lambda: timezone.now() + datetime.timedelta(days=2)

--- a/youths/tests/factories.py
+++ b/youths/tests/factories.py
@@ -22,6 +22,12 @@ class MyProfileAPIResponse(ProfileAPIResponse):
     last_name = factory.Faker("last_name")
 
 
+class RestrictedProfileAPIResponse(MyProfileAPIResponse):
+    """Data returned from ProfileAPI.fetch_profile_with_temporary_access_token."""
+
+    email = factory.Faker("email")
+
+
 class ProfileAPITokenResponse(factory.DictFactory):
     """Data returned from ProfileAPI.create_temporary_access_token."""
 
@@ -39,6 +45,10 @@ class YouthProfileFactory(factory.django.DjangoModelFactory):
     approver_email = factory.Faker("email")
     birth_date = "2002-02-02"
     approval_token = factory.Faker("uuid4")
+    profile_access_token = factory.Faker("uuid4")
+    profile_access_token_expiration = factory.LazyFunction(
+        lambda: timezone.now() + datetime.timedelta(days=2)
+    )
 
     class Meta:
         model = YouthProfile

--- a/youths/tests/test_graphql_api_additional_contact_persons.py
+++ b/youths/tests/test_graphql_api_additional_contact_persons.py
@@ -2,6 +2,7 @@ from string import Template
 
 from graphql_relay import to_global_id
 
+from common_utils.profile import ProfileAPI
 from youths.models import AdditionalContactPerson
 from youths.tests.factories import (
     AdditionalContactPersonDictFactory,
@@ -204,8 +205,13 @@ def test_normal_user_can_query_additional_contact_persons(
 
 
 def test_profile_approval_allows_changing_contact_persons(
-    rf, anon_user_gql_client, youth_profile
+    rf, anon_user_gql_client, youth_profile, mocker, restricted_profile_response
 ):
+    mocker.patch.object(
+        ProfileAPI,
+        "fetch_profile_with_temporary_access_token",
+        return_value=restricted_profile_response,
+    )
     request = rf.post("/graphql")
     request.user = anon_user_gql_client.user
 

--- a/youths/utils.py
+++ b/youths/utils.py
@@ -80,7 +80,7 @@ def generate_notifications():
         )
         fi_subject = "Vahvista nuorisojäsenyys"
         fi_html = (
-            "Hei {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} on "
+            "Hei {{ youth_profile.approver_first_name }},<br /><br />{{ youth_name }} on "
             "pyytänyt sinua vahvistamaan nuorisojäsenyytensä. Käy antamassa vahvistus Jässäri-palvelussa käyttäen "
             'tätä linkkiä:<br /><br /><a href="https://jassari.test.kuva.hel.ninja/approve'
             '/{{ youth_profile.approval_token }}/{{ youth_profile.profile_access_token }}">'
@@ -89,7 +89,7 @@ def generate_notifications():
             "automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä.</i>"
         )
         fi_text = (
-            "Hei {{ youth_profile.approver_first_name }},\r\n\r\n{{ youth_profile.profile.first_name }} on pyytänyt "
+            "Hei {{ youth_profile.approver_first_name }},\r\n\r\n{{ youth_name }} on pyytänyt "
             "sinua vahvistamaan nuorisojäsenyytensä. Käy antamassa vahvistus Jässäri-palvelussa käyttäen tätä linkkiä:"
             "\r\n\r\nhttps://jassari.test.kuva.hel.ninja/approve/{{ youth_profile.approval_token }}"
             "/{{ youth_profile.profile_access_token }}\r\n\r\nTämä viesti on lähetetty järjestelmästä automaattisesti. "
@@ -117,14 +117,14 @@ def generate_notifications():
         )
         fi_subject = "Nuorisojäsenyys vahvistettu"
         fi_html = (
-            "Hei {{ youth_profile.profile.first_name }},\r\n<br /><br />\r\n{{ youth_profile.approver_first_name }} on "
+            "Hei {{ youth_name }},\r\n<br /><br />\r\n{{ youth_profile.approver_first_name }} on "
             "vahvistanut nuorisojäsenyytesi. Kirjaudu Jässäri-palveluun nähdäksesi omat tietosi:\r\n<br /><br />\r\n"
             '<a href="https://jassari.test.kuva.hel.ninja">https://jassari.test.kuva.hel.ninja</a>\r\n<br /><br />\r\n'
             "<i>Tämä viesti on lähetetty järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia "
             "ei käsitellä.</i>"
         )
         fi_text = (
-            "Hei {{ youth_profile.profile.first_name }},\r\n\r\n{{ youth_profile.approver_first_name }} on vahvistanut "
+            "Hei {{ youth_name }},\r\n\r\n{{ youth_profile.approver_first_name }} on vahvistanut "
             "nuorisojäsenyytesi. Kirjaudu Jässäri-palveluun nähdäksesi omat tietosi:\r\n\r\n"
             "https://jassari.test.kuva.hel.ninja\r\n\r\nTämä viesti on lähetetty järjestelmästä automaattisesti. Älä "
             "vastaa tähän viestiin, sillä vastauksia ei käsitellä."


### PR DESCRIPTION
Additional information (like youth's name and email) is fetched from Helsinki profile backend for youth membership approval and confirmation messages using either the Helsinki profile API token provided during a mutation call or using the temporary access token saved into to youth profile.

* `approveYouthPprofile` mutations will respond with `TOKEN_EXPIRED_ERROR` if the temporary access token for Helsinki profile is considered expired (or it's not stored in the backend) in which case the approval notification should be regenerated with `renewMyYouthProfile`