### PR TITLE
YM-388 | Remove django-reversion DB table from QA

### DIFF
--- a/.prod/on_deploy.sh
+++ b/.prod/on_deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 python /app/manage.py migrate --noinput
+python /app/manage.py migrate reversion zero --noinput
 
 python /app/manage.py seed_data
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,7 @@ fi
 if [[ "$APPLY_MIGRATIONS" = "1" ]]; then
     echo "Applying database migrations..."
     ./manage.py migrate --noinput
+    ./manage.py migrate reversion zero --noinput
 fi
 
 # Create admin user. Generate password if there isn't one in the environment variables

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,7 @@ django-helusers
 django-ilmoitin
 django-import-export
 django-parler
+django-reversion
 django-sequences
 djangorestframework
 graphene-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,9 @@ django-ilmoitin==0.6.0    # via -r requirements.in
 django-import-export==2.4.0  # via -r requirements.in
 django-mailer==2.0.1      # via django-ilmoitin
 django-parler==2.2        # via -r requirements.in, django-ilmoitin
+django-reversion==3.0.8   # via -r requirements.in
 django-sequences==2.5     # via -r requirements.in
-django==2.2.17            # via -r requirements.in, django-admin-sortable, django-anymail, django-cors-headers, django-filter, django-graphql-jwt, django-helusers, django-ilmoitin, django-import-export, django-mailer, django-sequences, djangorestframework, drf-oidc-auth, graphene-django
+django==2.2.17            # via -r requirements.in, django-admin-sortable, django-anymail, django-cors-headers, django-filter, django-graphql-jwt, django-helusers, django-ilmoitin, django-import-export, django-mailer, django-reversion, django-sequences, djangorestframework, drf-oidc-auth, graphene-django
 djangorestframework==3.12.1  # via -r requirements.in, drf-oidc-auth
 drf-oidc-auth==0.10.0     # via django-helusers
 ecdsa==0.14.1             # via python-jose

--- a/youth_membership/settings.py
+++ b/youth_membership/settings.py
@@ -161,6 +161,7 @@ INSTALLED_APPS = [
     "graphene_django",
     "adminsortable",
     "import_export",
+    "reversion",
     # Local apps
     "users",
     "youths",


### PR DESCRIPTION
This PR should remove will remove django-reversion related DB tables from QA which cause `IntegrityError` errors.

Refs YM-388

P.S. This code will be reverted once the reversion migrations have been reversed in QA.