### PR TITLE
YM-424 | Add OIDC client secret into CI review env

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ review:
         K8S_SECRET_TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX: "jassariapi"
         K8S_SECRET_TOKEN_AUTH_AUTHSERVER_URL: "https://api.hel.fi/sso-test"
         K8S_SECRET_TOKEN_AUTH_REQUIRE_SCOPE: 1
+        K8S_SECRET_OIDC_CLIENT_ID: "$GL_QA_OIDC_CLIENT_ID"
         K8S_SECRET_OIDC_CLIENT_SECRET: "$GL_QA_OIDC_CLIENT_SECRET"
         K8S_SECRET_HELSINKI_PROFILE_AUTH_SCOPE: "https://api.hel.fi/auth/helsinkiprofile"
         K8S_SECRET_HELSINKI_PROFILE_AUTH_CALLBACK_URL: "https://jassari.test.kuva.hel.ninja/callback"


### PR DESCRIPTION
This PR adds a missing OIDC client secret into the CI review environments.