### PR TITLE
Remove the user related to the youth profile deleted using the GDPR API

### DIFF
--- a/common_utils/views/gdpr.py
+++ b/common_utils/views/gdpr.py
@@ -38,7 +38,9 @@ class GDPRScopesPermission(IsAuthenticated):
         return False
 
     def has_object_permission(self, request, view, obj):
-        return request.user == obj.user
+        if obj.user:
+            return request.user == obj.user
+        return False
 
 
 class GDPRAPIView(APIView):

--- a/common_utils/views/gdpr.py
+++ b/common_utils/views/gdpr.py
@@ -86,7 +86,10 @@ class GDPRAPIView(APIView):
         """
         try:
             with transaction.atomic():
-                self.get_object().delete()
+                obj = self.get_object()
+                user = obj.user
+                obj.delete()
+                user.delete()
                 self.check_dry_run()
         except DryRunException:
             # Deletion is possible. Due to dry run, transaction is rolled back.

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,3 +1,4 @@
+-c requirements.txt
 autoflake
 autopep8
 black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,20 +4,22 @@
 #
 #    pip-compile requirements-dev.in
 #
+--no-binary psycopg2
+
 appdirs==1.4.4            # via black, virtualenv
 attrs==20.2.0             # via flake8-bugbear, pytest
 autoflake==1.4            # via -r requirements-dev.in
 autopep8==1.5.4           # via -r requirements-dev.in
 backcall==0.2.0           # via ipython
 black==20.8b1             # via -r requirements-dev.in
-certifi==2020.6.20        # via requests
+certifi==2020.6.20        # via -c requirements.txt, requests
 cfgv==3.2.0               # via pre-commit
-chardet==3.0.4            # via requests
+chardet==3.0.4            # via -c requirements.txt, requests
 click==7.1.2              # via black, pip-tools
 coverage==5.3             # via pytest-cov
 decorator==4.4.2          # via ipython
 distlib==0.3.1            # via virtualenv
-ecdsa==0.14.1             # via python-jose
+ecdsa==0.14.1             # via -c requirements.txt, python-jose
 factory-boy==3.1.0        # via -r requirements-dev.in, pytest-factoryboy
 faker==4.14.0             # via factory-boy
 fastdiff==0.2.0           # via snapshottest
@@ -27,7 +29,7 @@ flake8-polyfill==1.0.2    # via pep8-naming
 flake8==3.8.4             # via -r requirements-dev.in, flake8-bugbear, flake8-polyfill
 freezegun==1.0.0          # via -r requirements-dev.in
 identify==1.5.6           # via pre-commit
-idna==2.10                # via requests
+idna==2.10                # via -c requirements.txt, requests
 importmagic==0.1.7        # via -r requirements-dev.in
 inflection==0.5.1         # via pytest-factoryboy
 iniconfig==1.1.1          # via pytest
@@ -50,7 +52,7 @@ pre-commit==2.8.2         # via -r requirements-dev.in
 prompt-toolkit==3.0.8     # via ipython
 ptyprocess==0.6.0         # via pexpect
 py==1.9.0                 # via pytest
-pyasn1==0.4.8             # via python-jose, rsa
+pyasn1==0.4.8             # via -c requirements.txt, python-jose, rsa
 pycodestyle==2.6.0        # via autopep8, flake8
 pydocstyle==5.1.1         # via -r requirements-dev.in
 pyflakes==2.2.0           # via autoflake, flake8
@@ -63,14 +65,14 @@ pytest-lazy-fixture==0.6.3  # via -r requirements-dev.in
 pytest-mock==3.5.0        # via -r requirements-dev.in
 pytest==6.1.2             # via -r requirements-dev.in, pytest-cov, pytest-django, pytest-factoryboy, pytest-lazy-fixture, pytest-mock
 python-dateutil==2.8.1    # via faker, freezegun
-python-jose==3.2.0        # via -r requirements-dev.in
-pyyaml==5.3.1             # via pre-commit
+python-jose==3.2.0        # via -c requirements.txt, -r requirements-dev.in
+pyyaml==5.3.1             # via -c requirements.txt, pre-commit
 regex==2020.10.28         # via black
 requests-mock==1.8.0      # via -r requirements-dev.in
-requests==2.24.0          # via requests-mock
+requests==2.24.0          # via -c requirements.txt, requests-mock
 rope==0.18.0              # via -r requirements-dev.in
-rsa==4.6                  # via python-jose
-six==1.15.0               # via ecdsa, packaging, pip-tools, python-dateutil, python-jose, requests-mock, snapshottest, virtualenv
+rsa==4.6                  # via -c requirements.txt, python-jose
+six==1.15.0               # via -c requirements.txt, ecdsa, packaging, pip-tools, python-dateutil, python-jose, requests-mock, snapshottest, virtualenv
 snapshottest==0.6.0       # via -r requirements-dev.in
 snowballstemmer==2.0.0    # via pydocstyle
 termcolor==1.1.0          # via snapshottest
@@ -79,7 +81,7 @@ toml==0.10.2              # via autopep8, black, pre-commit, pytest
 traitlets==5.0.5          # via ipython
 typed-ast==1.4.1          # via black
 typing-extensions==3.7.4.3  # via black
-urllib3==1.25.11          # via requests
+urllib3==1.25.11          # via -c requirements.txt, requests
 virtualenv==20.1.0        # via pre-commit
 wasmer==0.4.1             # via fastdiff
 wcwidth==0.2.5            # via prompt-toolkit

--- a/youths/tests/test_gdpr_api.py
+++ b/youths/tests/test_gdpr_api.py
@@ -1,6 +1,7 @@
 import datetime
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from helusers.settings import api_token_auth_settings
 from jose import jwt
@@ -8,6 +9,8 @@ from jose import jwt
 from youths.models import YouthProfile
 
 from .keys import rsa_key
+
+User = get_user_model()
 
 TRUE_VALUES = ["true", "True", "TRUE", "1", 1, True]
 FALSE_VALUES = ["false", "False", "FALSE", "0", 0, False]
@@ -97,6 +100,7 @@ def test_delete_profile_dry_run_data(
 
     assert response.status_code == 204
     assert YouthProfile.objects.count() == 1
+    assert User.objects.count() == 1
 
 
 @pytest.mark.parametrize("true_value", TRUE_VALUES)
@@ -114,6 +118,7 @@ def test_delete_profile_dry_run_query_params(
 
     assert response.status_code == 204
     assert YouthProfile.objects.count() == 1
+    assert User.objects.count() == 1
 
 
 def test_delete_profile(api_client, youth_profile, requests_mock, settings):
@@ -127,6 +132,7 @@ def test_delete_profile(api_client, youth_profile, requests_mock, settings):
 
     assert response.status_code == 204
     assert YouthProfile.objects.count() == 0
+    assert User.objects.count() == 0
 
 
 @pytest.mark.parametrize("false_value", FALSE_VALUES)
@@ -144,6 +150,7 @@ def test_delete_profile_dry_run_query_params_false(
 
     assert response.status_code == 204
     assert YouthProfile.objects.count() == 0
+    assert User.objects.count() == 0
 
 
 @pytest.mark.parametrize("false_value", FALSE_VALUES)
@@ -162,6 +169,7 @@ def test_delete_profile_dry_run_data_false(
 
     assert response.status_code == 204
     assert YouthProfile.objects.count() == 0
+    assert User.objects.count() == 0
 
 
 def test_gdpr_api_requires_authentication(api_client, youth_profile, snapshot):
@@ -242,3 +250,4 @@ def test_gdpr_delete_requires_correct_scope(
     else:
         assert response.status_code == 403
         assert YouthProfile.objects.count() == 1
+        assert User.objects.count() == 1


### PR DESCRIPTION
This PR adds logic which also removes the related `User` model instance when a `YouthProfile` instance is removed using the GDPR API. Also a small extra check to the GDPR API permissions is added to make sure only youth profiles with a user connection can be accessed.

Development requirement package versions are constrained by the package versions in `requirements.txt`.