### PR TITLE
Unset YouthProfile.approval_token on data import

### DIFF
--- a/youths/management/commands/import_youth_data.py
+++ b/youths/management/commands/import_youth_data.py
@@ -54,6 +54,8 @@ class Command(BaseCommand):
                 last=max_membership_number
             )
 
+            YouthProfile.objects.update(approval_token="")
+
             admin_group = generate_admin_group()
             for ad_group in ADGroup.objects.all():
                 ADGroupMapping.objects.create(group=admin_group, ad_group=ad_group)


### PR DESCRIPTION
Youth profile approval in the new updated flow requires a temporary approval token to be in place at Helsinki profile backend. Since it will not be, the `approval_token` should be cleared in import.

Refs YM-296