### PR TITLE
YM-463 | Fix membership status logic

### DIFF
--- a/youths/models.py
+++ b/youths/models.py
@@ -123,6 +123,12 @@ class YouthProfile(AuditLogModel, UUIDModel, SerializableMixin):
             return MembershipStatus.ACTIVE
         return MembershipStatus.PENDING
 
+    @property
+    def renewable(self):
+        return bool(self.approved_time) and self.expiration != calculate_expiration(
+            date.today()
+        )
+
     def __str__(self):
         if self.user:
             return "{} {} ({})".format(

--- a/youths/schema/types.py
+++ b/youths/schema/types.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 import django_filters
 import graphene
 from django.core.exceptions import PermissionDenied
@@ -13,7 +11,7 @@ from graphql_jwt.decorators import login_required
 from common_utils.graphql import CountConnection
 
 from ..enums import MembershipStatus, YouthLanguage
-from ..models import AdditionalContactPerson, calculate_expiration, YouthProfile
+from ..models import AdditionalContactPerson, YouthProfile
 from ..utils import user_is_admin
 
 with override("en"):
@@ -89,11 +87,6 @@ class YouthProfileNode(DjangoObjectType):
         description="Tells if the membership is currently renewable or not",
         required=True,
     )
-
-    def resolve_renewable(self: YouthProfile, info, **kwargs):
-        return bool(self.approved_time) and self.expiration != calculate_expiration(
-            date.today()
-        )
 
     def resolve_profile(self: YouthProfile, info, **kwargs):
         return self


### PR DESCRIPTION
This PR simplifies the logic for determining the membership status of a youth profile. It should also fix few cases which were missed e.g. regarding profiles with RENEWING status.

Status will be determined in this order:
1. if expiration < today => expired
2. if profile hasn't been approved by a guardian => PENDING
3. if expiration > calculated expiration based on approval time => RENEWING
4. Profile is ACTIVE if none of the previous statements were true.

The PR also refactors the renewable logic a bit. A youth profile is considered to be renewable always when the status is `EXPIRED`. Also the profile can be renewed if the profile has been approved at least once and the current expiration date differs from the calculated expiration date. On most cases this means that even an ACTIVE profile can be renewed after 1.5. 