### PR TITLE
YM-463 YM-469 | Fine tune YouthProfile RENEWING membership status logic

### DIFF
--- a/youths/tests/test_graphql_mutations.py
+++ b/youths/tests/test_graphql_mutations.py
@@ -957,7 +957,7 @@ def test_youth_profile_expiration_should_renew_and_be_approvable(
                 }
             }
         """
-        expected_data = {"myYouthProfile": {"membershipStatus": "RENEWING"}}
+        expected_data = {"myYouthProfile": {"membershipStatus": "PENDING"}}
         executed = user_gql_client.execute(query, context=request)
         assert dict(executed["data"]) == expected_data
 

--- a/youths/tests/test_models.py
+++ b/youths/tests/test_models.py
@@ -193,12 +193,20 @@ def test_additional_contact_person_runs_full_clean_when_saving(youth_profile):
             MembershipStatus.RENEWING,
             False,
         ),
-        # Short season renewal
+        # Full season renewal (next year), membership has expired, but renewal waiting for approval
+        (
+            "2020-09-01",
+            datetime.datetime(2020, 1, 1),
+            datetime.date(2021, 8, 31),
+            MembershipStatus.PENDING,
+            False,
+        ),
+        # Short season renewal, membership is expired, but it's waiting for approval
         (
             "2020-04-18",
             datetime.datetime(2019, 1, 1),
             datetime.date(2020, 8, 31),
-            MembershipStatus.RENEWING,
+            MembershipStatus.PENDING,
             False,
         ),
         # Last day of validity


### PR DESCRIPTION
While a youth profile is being renewed and it's still waiting for an approval from a guardian, the RENEWING status is returned
for a profile which is still active while the renewal is ongoing. PENDING will be returned for an expired youth profile, which is waiting for the approval from a guardian.

Different status now are:
- ACTIVE = membership is active
- PENDING = membership is waiting for approval and is either inactive or expired
- RENEWING = membership is active, but renewal is waiting for approval
- EXPIRED = membership has expired

Refs YM-463, YM-469