### PR TITLE
YM-465 | Stop logging requests for /healthz and /readiness endoints

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -8,3 +8,6 @@ gid = nogroup
 master = 1
 processes = 2
 threads = 2
+; don't log readiness and healthz endpoints
+route = ^/readiness$ donotlog:
+route = ^/healthz$ donotlog:


### PR DESCRIPTION
This PR stops uWSGI from logging requests for /healthz and /readiness endoints.