### PR TITLE
YM-500 | Add French to YouthLanguage

### DIFF
--- a/youths/enums.py
+++ b/youths/enums.py
@@ -15,6 +15,7 @@ class YouthLanguage(Enum):
     ARABIC = "ar"
     ESTONIAN = "et"
     RUSSIAN = "ru"
+    FRENCH = "fr"
 
     class Labels:
         FINNISH = _("Finnish")
@@ -24,6 +25,7 @@ class YouthLanguage(Enum):
         ARABIC = _("Arabic")
         ESTONIAN = _("Estonian")
         RUSSIAN = _("Russian")
+        FRENCH = _("French")
 
     # @classmethod
     # def to_graphene_enum(cls):


### PR DESCRIPTION
[YM-480](https://helsinkisolutionoffice.atlassian.net/browse/YM-480) assumes that the supported languages includes French. In order to allow users to set their "language at home" value to French, we extend the YouthLangauge enum to include it.

@charn Please advise if I've overlooked something.