### PR TITLE
Notification template updates

### DIFF
--- a/youth_membership/settings.py
+++ b/youth_membership/settings.py
@@ -251,6 +251,8 @@ PARLER_LANGUAGES = {
     "default": {"fallbacks": ["fi"], "hide_untranslated": False},
 }
 
+PARLER_ENABLE_CACHING = False
+
 # Notification settings
 
 NOTIFICATIONS_ENABLED = True


### PR DESCRIPTION
This PR syncs the notification templates which are created for a new backend instances with the current production versions. The templates now include language specific URLs.

Also `django-parler` caching is disabled since Django's default `LocMemCache` can cause display issues e.g. when updating the template translations and the service is run on more than one process (which happens on our production and staging environments).