### PR TITLE
FIX YM-479 | Provide base url value directly

### DIFF
--- a/youths/models.py
+++ b/youths/models.py
@@ -80,7 +80,11 @@ class YouthProfile(AuditLogModel, UUIDModel, SerializableMixin):
         send_notification(
             email=self.approver_email,
             notification_type=NotificationType.YOUTH_PROFILE_CONFIRMATION_NEEDED.value,
-            context={"youth_profile": self, "youth_name": youth_name},
+            context={
+                "youth_profile": self,
+                "youth_name": youth_name,
+                "youth_membership_ui_base_url": settings.EMAIL_TEMPLATE_YOUTH_MEMBERSHIP_UI_BASE_URL,
+            },
             language=self.language_at_home.value,
         )
         self.approval_notification_timestamp = timezone.now()

--- a/youths/schema/mutations.py
+++ b/youths/schema/mutations.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 import graphene
+from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 from django_ilmoitin.utils import send_notification
@@ -423,6 +424,7 @@ class ApproveYouthProfileMutation(relay.ClientIDMutation):
             context={
                 "youth_profile": youth_profile,
                 "youth_name": profile_data["first_name"],
+                "youth_membership_ui_base_url": settings.EMAIL_TEMPLATE_YOUTH_MEMBERSHIP_UI_BASE_URL,
             },
             language=profile_data["language"],
         )

--- a/youths/tests/test_graphql_mutations.py
+++ b/youths/tests/test_graphql_mutations.py
@@ -1,6 +1,7 @@
 import json
 from datetime import date, datetime, timedelta
 from string import Template
+from unittest.mock import ANY
 
 import pytest
 from django.utils import timezone
@@ -90,6 +91,7 @@ def test_normal_user_can_create_youth_profile_mutation(
     assert mocked_notification.call_args.kwargs["context"] == {
         "youth_profile": YouthProfile.objects.get(pk=profile_id),
         "youth_name": my_profile_api_response["first_name"],
+        "youth_membership_ui_base_url": ANY,
     }
 
 
@@ -505,6 +507,7 @@ def test_normal_user_can_resend_request_notification_on_update(
         assert mocked_notification.call_args.kwargs["context"] == {
             "youth_profile": YouthProfile.objects.get(pk=youth_profile.pk),
             "youth_name": my_profile_api_response["first_name"],
+            "youth_membership_ui_base_url": ANY,
         }
     else:
         assert youth_profile.approval_token == original_approval_token
@@ -817,6 +820,7 @@ def test_approving_with_token_sends_confirmation_message(
     assert mocked_notification.call_args.kwargs["context"] == {
         "youth_profile": YouthProfile.objects.get(pk=youth_profile.pk),
         "youth_name": restricted_profile_response["first_name"],
+        "youth_membership_ui_base_url": ANY,
     }
     assert (
         mocked_notification.call_args.kwargs["email"]
@@ -1043,6 +1047,7 @@ def test_youth_profile_renewal_sends_approval_message_for_a_minor(
         assert mocked_notification.call_args.kwargs["context"] == {
             "youth_profile": YouthProfile.objects.get(pk=youth_profile.pk),
             "youth_name": my_profile_api_response["first_name"],
+            "youth_membership_ui_base_url": ANY,
         }
 
 


### PR DESCRIPTION
Provides the Jassari service url directly when invoking `send_notification` to fix crash caused by missing context value.