### PR TITLE
Fix styling issues in some email clients

### DIFF
--- a/common_utils/tests/snapshots/snap_test_commands.py
+++ b/common_utils/tests/snapshots/snap_test_commands.py
@@ -214,21 +214,26 @@ snapshots[
 <br />
 <br />
 
-<a
-    href="{{ youth_membership_ui_base_url }}/en/"
-    style="
-        background: rgb(0, 0, 191);
-        padding: 20px 32px;
-        color: #ffffff;
-        font-size: 16px;
-        font-weight: 500;
-        height: 24px;
-        line-height: 24px;
-        text-align: center;
-        display: inline-block;
-        text-decoration: none;
-    "
->Jässäri <img src="https://jassari.test.kuva.hel.ninja/email-templates/hds-icon-arrow-right.png" style="vertical-align: middle; margin-left: 12px;" /></a>
+<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+    <tr>
+        <td align="center" bgcolor="#0000BF" role="presentation" style="border:none;cursor:auto;padding: 20px 32px;background:#0000BF;" valign="middle">
+            <a
+                href="{{ youth_membership_ui_base_url }}/en/"
+                style="
+                    background: #0000BF;
+                    color: #ffffff;
+                    font-size: 16px;
+                    font-weight: 500;
+                    height: 24px;
+                    line-height: 24px;
+                    text-align: center;
+                    display: inline-block;
+                    text-decoration: none;
+                "
+            >Jässäri <img src="https://jassari.test.kuva.hel.ninja/email-templates/hds-icon-arrow-right.png" style="vertical-align: middle; margin-left: 12px;" /></a>
+        </td>
+    </tr>
+</table>
 
 <br />
 <br />

--- a/common_utils/tests/snapshots/snap_test_commands.py
+++ b/common_utils/tests/snapshots/snap_test_commands.py
@@ -211,8 +211,8 @@ snapshots[
                                         
 
 {{ youth_profile.approver_first_name }} has approved your membership. Your digital memberhsip card can be found here:
-</br>
-</br>
+<br />
+<br />
 
 <a
     href="{{ youth_membership_ui_base_url }}/en/"
@@ -230,8 +230,8 @@ snapshots[
     "
 >Jässäri <img src="https://jassari.test.kuva.hel.ninja/email-templates/hds-icon-arrow-right.png" style="vertical-align: middle; margin-left: 12px;" /></a>
 
-</br>
-</br>
+<br />
+<br />
 For more information on the Youth Services membership and its perks, please visit <a
     href="https://jassari.munstadi.fi/en/"
     style="color: #0e04c7;text-decoration: none;"
@@ -239,8 +239,8 @@ For more information on the Youth Services membership and its perks, please visi
     https://jassari.munstadi.fi/en/
 </a>.
 
-                                        </br>
-                                        </br>
+                                        <br />
+                                        <br />
                                         <span style="font-size: 16px; color: #666666;">
 This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.
 </span>

--- a/templates/jinja2/email/base_generic.html
+++ b/templates/jinja2/email/base_generic.html
@@ -182,8 +182,8 @@
                                         "
                                     >
                                         {% block content %}{% endblock %}
-                                        </br>
-                                        </br>
+                                        <br />
+                                        <br />
                                         <span style="font-size: 16px; color: #666666;">{% block disclaimer %}{% endblock %}</span>
                                     </td>
                                 </tr>

--- a/templates/jinja2/email/macros.jinja
+++ b/templates/jinja2/email/macros.jinja
@@ -1,19 +1,24 @@
 {% macro buttonLink(label, href) -%}
-<a
-    href="{{ href }}"
-    style="
-        background: rgb(0, 0, 191);
-        padding: 20px 32px;
-        color: #ffffff;
-        font-size: 16px;
-        font-weight: 500;
-        height: 24px;
-        line-height: 24px;
-        text-align: center;
-        display: inline-block;
-        text-decoration: none;
-    "
->{{ label }} <img src="{{ image_location }}/hds-icon-arrow-right.png" style="vertical-align: middle; margin-left: 12px;" /></a>
+<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+    <tr>
+        <td align="center" bgcolor="#0000BF" role="presentation" style="border:none;cursor:auto;padding: 20px 32px;background:#0000BF;" valign="middle">
+            <a
+                href="{{ href }}"
+                style="
+                    background: #0000BF;
+                    color: #ffffff;
+                    font-size: 16px;
+                    font-weight: 500;
+                    height: 24px;
+                    line-height: 24px;
+                    text-align: center;
+                    display: inline-block;
+                    text-decoration: none;
+                "
+            >{{ label }} <img src="{{ image_location }}/hds-icon-arrow-right.png" style="vertical-align: middle; margin-left: 12px;" /></a>
+        </td>
+    </tr>
+</table>
 {%- endmacro %}
 
 {% macro logo(variant="header", lang="fi") -%}

--- a/templates/jinja2/email/messages/youth_profile_confirmation_needed_en.html
+++ b/templates/jinja2/email/messages/youth_profile_confirmation_needed_en.html
@@ -4,14 +4,14 @@
 {% block content %}
 {% raw %}
 Hi {{ youth_profile.approver_first_name }},
-</br>
-</br>
+<br />
+<br />
 {{ youth_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge.
-</br>
-</br>
+<br />
+<br />
 If you approve the application, {{ youth_name }} may visit Youth Centres and enjoy fun benefits. If the information is incorrect, ask the youth to change it and send a new approval request to you. You can give your approval using the Jässäri service via this link:
-</br>
-</br>
+<br />
+<br />
 {% endraw %}
 {{ macros.buttonLink("View the Application", "{{ youth_membership_ui_base_url }}/en/approve/{{ youth_profile.approval_token }}/{{ youth_profile.profile_access_token }}")  }}
 {% endblock %}

--- a/templates/jinja2/email/messages/youth_profile_confirmation_needed_fi.html
+++ b/templates/jinja2/email/messages/youth_profile_confirmation_needed_fi.html
@@ -4,14 +4,14 @@
 {% block content %}
 {% raw %}
 Hei {{ youth_profile.approver_first_name }},
-</br>
-</br>
+<br />
+<br />
 {{ youth_name }} on lähettänyt hyväksyttäväksesi Helsingin kaupungin nuorisopalvelujen jäsenyyshakemuksen. Jäsenyys on maksuton.
-</br>
-</br>
+<br />
+<br />
 Hyväksymällä hakemuksen, {{ youth_name }} voi käydä nuorisotalolla ja saa kivoja etuja. Mikäli tiedoissa on virheitä, pyydä nuorta muuttamaan tiedot ja lähettämään sinulle uusi varmistusviesti. Käy antamassa vahvistus Jässäri-palvelussa käyttäen tätä linkkiä:
-</br>
-</br>
+<br />
+<br />
 {% endraw %}
 {{ macros.buttonLink("Tarkastele hakemusta", "{{ youth_membership_ui_base_url }}/fi/approve/{{ youth_profile.approval_token }}/{{ youth_profile.profile_access_token }}")  }}
 {% endblock %}

--- a/templates/jinja2/email/messages/youth_profile_confirmation_needed_sv.html
+++ b/templates/jinja2/email/messages/youth_profile_confirmation_needed_sv.html
@@ -4,14 +4,14 @@
 {% block content %}
 {% raw %}
 Hej {{ youth_profile.approver_first_name }},
-</br>
-</br>
+<br />
+<br />
 {{ youth_name }} har skickat dig en ansökan om medlemskap i Helsingfors stads ungdomstjänster för godkännande. Medlemskapet är kostnadsfritt.
-</br>
-</br>
+<br />
+<br />
 Om du godkänner ansökan, kan {{ youth_name }} delta i ungdomsgårdarnas verksamhet och få trevliga förmåner. Om det finns fel i uppgifterna, be den unga att korrigera dem och sedan skicka ett nytt bekräftelsemeddelande till dig. Du kan ge ditt godkännande med Jässäri-tjänsten via denna länk:
-</br>
-</br>
+<br />
+<br />
 {% endraw %}
 {{ macros.buttonLink("Visa applikationen", "{{ youth_membership_ui_base_url }}/sv/approve/{{ youth_profile.approval_token }}/{{ youth_profile.profile_access_token }}")  }}
 {% endblock %}

--- a/templates/jinja2/email/messages/youth_profile_confirmed_en.html
+++ b/templates/jinja2/email/messages/youth_profile_confirmed_en.html
@@ -4,12 +4,12 @@
 {% block content %}
 {% raw %}
 {{ youth_profile.approver_first_name }} has approved your membership. Your digital memberhsip card can be found here:
-</br>
-</br>
+<br />
+<br />
 {% endraw %}
 {{ macros.buttonLink(label="Jässäri", href="{{ youth_membership_ui_base_url }}/en/") }}
 {% raw %}
-</br>
-</br>
+<br />
+<br />
 For more information on the Youth Services membership and its perks, please visit{% endraw %} {{ macros.link("https://jassari.munstadi.fi/en/", "https://jassari.munstadi.fi/en/") }}.
 {% endblock %}

--- a/templates/jinja2/email/messages/youth_profile_confirmed_fi.html
+++ b/templates/jinja2/email/messages/youth_profile_confirmed_fi.html
@@ -4,12 +4,12 @@
 {% block content %}
 {% raw %}
 {{ youth_profile.approver_first_name }} on hyväksynyt jäsenyytesi. Digitaalinen jäsenkorttisi löytyy täältä:
-</br>
-</br>
+<br />
+<br />
 {% endraw %}
 {{ macros.buttonLink(label="Jässäri", href="{{ youth_membership_ui_base_url }}/fi/") }}
 {% raw %}
-</br>
-</br>
+<br />
+<br />
 Lisätietoa nuorisopalveluiden jäsenyydestä ja sen eduista voit lukea osoitteesta {% endraw %} {{ macros.link("https://jassari.munstadi.fi", "https://jassari.munstadi.fi") }}.
 {% endblock %}

--- a/templates/jinja2/email/messages/youth_profile_confirmed_sv.html
+++ b/templates/jinja2/email/messages/youth_profile_confirmed_sv.html
@@ -4,12 +4,12 @@
 {% block content %}
 {% raw %}
 {{ youth_profile.approver_first_name }} har godkänt ditt edlemskap i Helsingfors stads ungdomstjänster. Ditt digitala medlemskort kan hittas här:
-</br>
-</br>
+<br />
+<br />
 {% endraw %}
 {{ macros.buttonLink(label="Jässäri", href="{{ youth_membership_ui_base_url }}/sv/") }}
 {% raw %}
-</br>
-</br>
+<br />
+<br />
 Mer information om medlemskapet i ungdomstjänsterna och förmånerna finns på adressen{% endraw %} {{ macros.link("https://jassari.munstadi.fi/sv/", "https://jassari.munstadi.fi/sv/") }}.
 {% endblock %}


### PR DESCRIPTION
These changes fix the way in which line breaks are declared in some of the templates. The old syntax is not valid HTML, but gets parsed by browsers and some email clients due to some quirk in the rendering logic.

The changes also alter the way in which the the CTA link is styled to appear like a button. Desktop Outlook poorly supported the previous approach.