### PR TITLE
Chore | Add possibility to manually trigger staging workflow.

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,6 +4,13 @@ on:
     branches:
       - master
 
+  workflow_dispatch:
+      inputs:
+          build_required:
+              description: "Build images (true/false)"
+              required: true
+              default: "false"
+
 env:
   CONTAINER_REGISTRY: ghcr.io
   CONTAINER_REGISTRY_USER: ${{ secrets.GHCR_CONTAINER_REGISTRY_USER }}
@@ -28,6 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build
+        if: github.event_name == 'push' || github.event.inputs.build_required == 'true'
         uses: andersinno/kolga-build-action@v2
 
   staging:


### PR DESCRIPTION
This PR adds `workflow_dispatch` trigger. With this in place it's possible to manually run staging workflow from Actions - tab.