### PR TITLE
Fix youth profile creation test

### DIFF
--- a/common_utils/views/graphql.py
+++ b/common_utils/views/graphql.py
@@ -105,7 +105,7 @@ class SentryGraphQLView(BaseGraphQLView):
     def format_error(error):
         def get_error_code(exception):
             """Get the most specific error code for the exception via superclass"""
-            for exception in exception.mro():
+            for exception in exception.mro():  # noqa B020
                 try:
                     return error_codes[exception]
                 except KeyError:

--- a/youths/tests/test_graphql_mutations.py
+++ b/youths/tests/test_graphql_mutations.py
@@ -25,6 +25,7 @@ from youths.tests.factories import (
 )
 
 
+@freeze_time("2020-05-02")
 def test_normal_user_can_create_youth_profile_mutation(
     rf, user_gql_client, mocker, my_profile_api_response, token_response
 ):


### PR DESCRIPTION
DEVOPS-490. A year has passed and the youth profile used in a test was not a youth anymore. Fixed by freezing the time to last year.